### PR TITLE
Added possibility of initialising cluster assignment from input

### DIFF
--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -71,7 +71,9 @@ class Coclustering(object):
                                 self.nclusters_col,
                                 self.conv_threshold,
                                 self.max_iterations,
-                                self.epsilon):
+                                self.epsilon,
+                                row_clusters_init=self.row_clusters,
+                                col_clusters_init=self.col_clusters):
                 r for r in range(self.nruns)
             }
             row_min, col_min, e_min = None, None, 0.
@@ -105,7 +107,9 @@ class Coclustering(object):
                 self.nclusters_col,
                 self.conv_threshold,
                 self.max_iterations,
-                self.epsilon
+                self.epsilon,
+                row_clusters_init=self.row_clusters,
+                col_clusters_init=self.col_clusters
             )
             e = e.compute()
             logger.info(f'Error = {e}')
@@ -132,6 +136,8 @@ class Coclustering(object):
                                       self.conv_threshold,
                                       self.max_iterations,
                                       self.epsilon,
+                                      row_clusters_init=self.row_clusters,
+                                      col_clusters_init=self.col_clusters,
                                       run_on_worker=True,
                                       pure=False)
                    for r in range(self.nruns)]
@@ -154,3 +160,17 @@ class Coclustering(object):
         self.row_clusters = row_min.compute()
         self.col_clusters = col_min.compute()
         self.error = e_min
+
+    def set_initial_clusters(self, row_clusters, col_clusters):
+        """
+        Set initial cluster assignment
+
+        :param row_clusters: initial row clusters
+        :param col_clusters: initial column clusters
+        """
+        if (not (row_clusters is None and col_clusters is None)
+                and self.nruns > 1):
+            logging.warning('Multiple runs with the same cluster '
+                            'initialization will be performed.')
+        self.row_clusters = row_clusters
+        self.col_clusters = col_clusters

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -25,7 +25,7 @@ class Coclustering(object):
         :param nclusters_col: number of column clusters
         :param conv_threshold: convergence threshold for the objective function
         :param max_iterations: maximum number of iterations
-        :param nruns: number of differntly-initialized runs
+        :param nruns: number of differently-initialized runs
         :param epsilon: numerical parameter, avoids zero arguments in log
         """
         self.Z = Z

--- a/cgc/coclustering_dask.py
+++ b/cgc/coclustering_dask.py
@@ -12,15 +12,19 @@ def _distance(Z, X, Y, epsilon):
 
 
 def _initialize_clusters(n_el, n_clusters):
-    """ Initialize cluster occupation matrix """
+    """ Initialize cluster array """
     cluster_idx = da.mod(da.arange(n_el), n_clusters)
-    cluster_idx = da.random.permutation(cluster_idx)
+    return da.random.permutation(cluster_idx)
+
+
+def _setup_cluster_matrix(n_clusters, cluster_idx):
+    """ Set cluster occupation matrix """
     # TODO: check if Z shape is larger than max int32?
-    eye = da.eye(n_clusters, dtype=np.int32)
-    return eye[cluster_idx]
+    return da.eye(n_clusters, dtype=np.int32)[cluster_idx]
 
 
 def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
+                 col_clusters_init=None, row_clusters_init=None,
                  run_on_worker=False):
     """
     Run the co-clustering, Dask implementation
@@ -31,6 +35,8 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
     :param errobj: convergence threshold for the objective function
     :param niters: maximum number of iterations
     :param epsilon: numerical parameter, avoids zero arguments in log
+    :param row_clusters_init: initial row cluster assignment
+    :param col_clusters_init: initial column cluster assignment
     :param run_on_worker: whether the function is submitted to a Dask worker
     :return: has converged, number of iterations performed. final row and
     column clustering, error value
@@ -39,8 +45,12 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
 
     [m, n] = Z.shape
 
-    R = _initialize_clusters(m, nclusters_row)
-    C = _initialize_clusters(n, nclusters_col)
+    row_clusters = row_clusters_init if row_clusters_init is not None \
+        else _initialize_clusters(m, nclusters_row)
+    col_clusters = col_clusters_init if col_clusters_init is not None \
+        else _initialize_clusters(n, nclusters_col)
+    R = _setup_cluster_matrix(nclusters_row, row_clusters)
+    C = _setup_cluster_matrix(nclusters_col, col_clusters)
 
     e, old_e = 2 * errobj, 0
     s = 0
@@ -57,13 +67,13 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
         d_row = _distance(Z, da.ones((m, n)), da.dot(C, CoCavg.T), epsilon)
         # Assign to best row cluster
         row_clusters = da.argmin(d_row, axis=1)
-        R = da.eye(nclusters_row, dtype=np.int32)[row_clusters]
+        R = _setup_cluster_matrix(nclusters_row, row_clusters)
 
         # Calculate distance based on column approximation
         d_col = _distance(Z.T, da.ones((n, m)), da.dot(R, CoCavg), epsilon)
         # Assign to best column cluster
         col_clusters = da.argmin(d_col, axis=1)
-        C = da.eye(nclusters_col, dtype=np.int32)[col_clusters]
+        C = _setup_cluster_matrix(nclusters_col, col_clusters)
 
         # Error value (actually just the column components really)
         old_e = e

--- a/cgc/coclustering_numpy.py
+++ b/cgc/coclustering_numpy.py
@@ -9,14 +9,18 @@ def _distance(Z, X, Y, epsilon):
 
 
 def _initialize_clusters(n_el, n_clusters):
-    """ Initialize cluster occupation matrix """
+    """ Initialize cluster array """
     cluster_idx = np.mod(np.arange(n_el), n_clusters)
-    cluster_idx = np.random.permutation(cluster_idx)
-    eye = np.eye(n_clusters, dtype=np.int32)
-    return eye[cluster_idx]
+    return np.random.permutation(cluster_idx)
 
 
-def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon):
+def _setup_cluster_matrix(n_clusters, cluster_idx):
+    """ Set cluster occupation matrix """
+    return np.eye(n_clusters, dtype=np.int32)[cluster_idx]
+
+
+def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
+                 row_clusters_init=None, col_clusters_init=None):
     """
     Run the co-clustering, Numpy-based implementation
 
@@ -26,13 +30,19 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon):
     :param errobj: convergence threshold for the objective function
     :param niters: maximum number of iterations
     :param epsilon: numerical parameter, avoids zero arguments in log
+    :param row_clusters_init: initial row cluster assignment
+    :param col_clusters_init: initial column cluster assignment
     :return: has converged, number of iterations performed, final row and
     column clustering, error value
     """
     [m, n] = Z.shape
 
-    R = _initialize_clusters(m, nclusters_row)
-    C = _initialize_clusters(n, nclusters_col)
+    row_clusters = row_clusters_init if row_clusters_init is not None \
+        else _initialize_clusters(m, nclusters_row)
+    col_clusters = col_clusters_init if col_clusters_init is not None \
+        else _initialize_clusters(n, nclusters_col)
+    R = _setup_cluster_matrix(nclusters_row, row_clusters)
+    C = _setup_cluster_matrix(nclusters_col, col_clusters)
 
     e, old_e = 2 * errobj, 0
     s = 0
@@ -49,13 +59,13 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon):
         d_row = _distance(Z, np.ones((m, n)), np.dot(C, CoCavg.T), epsilon)
         # Assign to best row cluster
         row_clusters = np.argmin(d_row, axis=1)
-        R = np.eye(nclusters_row, dtype=np.int32)[row_clusters]
+        R = _setup_cluster_matrix(nclusters_row, row_clusters)
 
         # Calculate distance based on column approximation
         d_col = _distance(Z.T, np.ones((n, m)), np.dot(R, CoCavg), epsilon)
         # Assign to best column cluster
         col_clusters = np.argmin(d_col, axis=1)
-        C = np.eye(nclusters_col, dtype=np.int32)[col_clusters]
+        C = _setup_cluster_matrix(nclusters_col, col_clusters)
 
         # Error value (actually just the column components really)
         old_e = e

--- a/cgc/triclustering.py
+++ b/cgc/triclustering.py
@@ -59,7 +59,11 @@ class Triclustering(object):
                                 self.nclusters_bnd,
                                 self.conv_threshold,
                                 self.max_iterations,
-                                self.epsilon):
+                                self.epsilon,
+                                row_clusters_init=self.row_clusters,
+                                col_clusters_init=self.col_clusters,
+                                bnd_clusters_init=self.bnd_clusters
+                                ):
                 r for r in range(self.nruns)
             }
             row_min, col_min, bnd_min, e_min = None, None, None, 0.
@@ -85,3 +89,21 @@ class Triclustering(object):
 
     def run_serial(self):
         raise NotImplementedError
+
+    def set_initial_clusters(self, row_clusters, col_clusters, bnd_clusters):
+        """
+        Set initial cluster assignment
+
+        :param row_clusters: initial row clusters
+        :param col_clusters: initial column clusters
+        :param bnd_clusters: initial band clusters
+        """
+        if (not (row_clusters is None
+                 and col_clusters is None
+                 and bnd_clusters is None)
+                and self.nruns > 1):
+            logging.warning('Multiple runs with the same cluster '
+                            'initialization will be performed.')
+        self.row_clusters = row_clusters
+        self.col_clusters = col_clusters
+        self.bnd_clusters = bnd_clusters

--- a/cgc/triclustering_numpy.py
+++ b/cgc/triclustering_numpy.py
@@ -80,15 +80,15 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
         CoCavg2 = (np.dot(np.dot(B.T, Y2), C2) + Gavg * epsilon) / (
                 np.dot(np.dot(B.T, np.ones((d, m * n))), C2) + epsilon)
 
-        # Calculate distance based on column approximation
+        # Calculate distance based on band approximation
         d2 = _distance(Y2, np.ones((d, m * n)), np.dot(C2, CoCavg2.T), epsilon)
 
-        # Assign to best column cluster
+        # Assign to best band cluster
         bnd_clusters = np.argmin(d2, axis=1)
         B = np.eye(nclusters_bnd)[bnd_clusters, :]
         C1 = np.tile(B, (n, 1))
 
-        # Error value (actually just the column components really)
+        # Error value
         old_e = e
         minvals = np.amin(d2, axis=1)
         # power 1 divergence, power 2 euclidean

--- a/cgc/triclustering_numpy.py
+++ b/cgc/triclustering_numpy.py
@@ -9,15 +9,19 @@ def _distance(Z, X, Y, epsilon):
 
 
 def _initialize_clusters(n_el, n_clusters):
-    """ Initialize cluster occupation matrix """
+    """ Initialize cluster array """
     cluster_idx = np.mod(np.arange(n_el), n_clusters)
-    cluster_idx = np.random.permutation(cluster_idx)
-    eye = np.eye(n_clusters, dtype=np.int32)
-    return eye[cluster_idx]
+    return np.random.permutation(cluster_idx)
+
+
+def _setup_cluster_matrix(n_clusters, cluster_idx):
+    """ Set cluster occupation matrix """
+    return np.eye(n_clusters, dtype=np.int32)[cluster_idx]
 
 
 def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
-                  niters, epsilon):
+                  niters, epsilon, row_clusters_init=None,
+                  col_clusters_init=None, bnd_clusters_init=None):
     """
     Run the tri-clustering, Numpy-based implementation
 
@@ -28,6 +32,9 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
     :param errobj: convergence threshold for the objective function
     :param niters: maximum number of iterations
     :param epsilon: numerical parameter, avoids zero arguments in log
+    :param row_clusters_init: initial row cluster assignment
+    :param col_clusters_init: initial column cluster assignment
+    :param bnd_clusters_init: initial band cluster assignment
     :return: has converged, number of iterations performed, final row,
     column, and band clustering, error value
     """
@@ -41,11 +48,19 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
     # Calculate average
     Gavg = Y.mean()
 
-    # Randomly initialize row and column clustering
-    R = _initialize_clusters(m, nclusters_row)
-    C1 = _initialize_clusters(n * d, nclusters_bnd)
-    C = _initialize_clusters(n, nclusters_col)
-    B = _initialize_clusters(d, nclusters_bnd)
+    # Initialize cluster assignments
+    row_clusters = row_clusters_init if row_clusters_init is not None \
+        else _initialize_clusters(m, nclusters_row)
+    col_clusters = col_clusters_init if col_clusters_init is not None \
+        else _initialize_clusters(n, nclusters_col)
+    bnd_clusters = bnd_clusters_init if bnd_clusters_init is not None \
+        else _initialize_clusters(d, nclusters_bnd)
+    x_clusters = np.tile(bnd_clusters, n) if bnd_clusters_init is not None \
+        else _initialize_clusters(n*d, nclusters_bnd)
+    R = _setup_cluster_matrix(nclusters_row, row_clusters)
+    C = _setup_cluster_matrix(nclusters_col, col_clusters)
+    B = _setup_cluster_matrix(nclusters_bnd, bnd_clusters)
+    C1 = _setup_cluster_matrix(nclusters_bnd, x_clusters)
 
     e, old_e = 2 * errobj, 0
     s = 0
@@ -61,7 +76,7 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
 
         # Assign to best row cluster
         row_clusters = np.argmin(d2, axis=1)
-        R = np.eye(nclusters_row)[row_clusters, :]
+        R = _setup_cluster_matrix(nclusters_row, row_clusters)
         R1 = np.tile(R, (d, 1))
 
         # Obtain all the cluster based averages
@@ -73,7 +88,7 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
 
         # Assign to best column cluster
         col_clusters = np.argmin(d2, axis=1)
-        C = np.eye(nclusters_col)[col_clusters, :]
+        C = _setup_cluster_matrix(nclusters_col, col_clusters)
         C2 = np.tile(C, (m, 1))
 
         # Obtain all the cluster based averages
@@ -85,7 +100,7 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
 
         # Assign to best band cluster
         bnd_clusters = np.argmin(d2, axis=1)
-        B = np.eye(nclusters_bnd)[bnd_clusters, :]
+        B = _setup_cluster_matrix(nclusters_bnd, bnd_clusters)
         C1 = np.tile(B, (n, 1))
 
         # Error value

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -9,9 +9,8 @@ from cgc.coclustering import Coclustering
 @pytest.fixture
 def coclustering():
     np.random.seed(1234)
-    da.random.seed(1234)
-    m, n = 4, 3
-    ncl_row, ncl_col = 2, 2
+    m, n = 10, 8
+    ncl_row, ncl_col = 5, 2
     Z = np.random.randint(100, size=(m, n)).astype('float64')
     return Coclustering(Z, nclusters_row=ncl_row, nclusters_col=ncl_col,
                         conv_threshold=1.e-5, max_iterations=100, nruns=10,
@@ -19,21 +18,37 @@ def coclustering():
 
 
 class TestCoclustering:
+    def test_check_initial_assignments(self, coclustering):
+        assert coclustering.row_clusters is None
+        assert coclustering.col_clusters is None
+
     def test_run_with_threads(self, coclustering):
+        coclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                          [0, 1, 0, 1, 0, 1, 0, 1])
         coclustering.run_with_threads(nthreads=2)
-        assert isinstance(coclustering.row_clusters, np.ndarray)
-        assert isinstance(coclustering.col_clusters, np.ndarray)
-        assert np.isclose(coclustering.error, -1430.4432279784644)
+        np.testing.assert_equal(coclustering.row_clusters,
+                                [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
+        np.testing.assert_equal(coclustering.col_clusters,
+                                [0, 0, 0, 1, 0, 0, 1, 1])
+        assert np.isclose(coclustering.error, -11554.1406004284)
 
     def test_dask_runs_memory(self, client, coclustering):
+        coclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                          [0, 1, 0, 1, 0, 1, 0, 1])
         coclustering._dask_runs_memory()
-        assert isinstance(coclustering.row_clusters, np.ndarray)
-        assert isinstance(coclustering.col_clusters, np.ndarray)
-        assert np.isclose(coclustering.error, -1430.4432279784644)
+        np.testing.assert_equal(coclustering.row_clusters,
+                                [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
+        np.testing.assert_equal(coclustering.col_clusters,
+                                [0, 0, 0, 1, 0, 0, 1, 1])
+        assert np.isclose(coclustering.error, -11554.1406004284)
 
     def test_dask_runs_performance(self, client, coclustering):
+        coclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                          [0, 1, 0, 1, 0, 1, 0, 1])
         coclustering.client = client
         coclustering._dask_runs_performance()
-        assert isinstance(coclustering.row_clusters, np.ndarray)
-        assert isinstance(coclustering.col_clusters, np.ndarray)
-        assert np.isclose(coclustering.error, -1430.4432279784644)
+        np.testing.assert_equal(coclustering.row_clusters,
+                                [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
+        np.testing.assert_equal(coclustering.col_clusters,
+                                [0, 0, 0, 1, 0, 0, 1, 1])
+        assert np.isclose(coclustering.error, -11554.1406004284)

--- a/tests/test_coclustering_dask.py
+++ b/tests/test_coclustering_dask.py
@@ -32,25 +32,21 @@ class TestInitializeClusters:
         m = 10
         k = 3
         clusters = coclustering_dask._initialize_clusters(m, k)
-        assert clusters.sum(axis=0).sum() == m
+        assert set(clusters.compute().tolist()) == {i for i in range(k)}
 
     def test_all_clusters_are_initialized(self):
         # if m == k, all clusters should have initial occupation one
         m = 10
         k = 10
         clusters = coclustering_dask._initialize_clusters(m, k)
-        num_el_per_cluster = clusters.sum(axis=0)
-        np.testing.assert_array_equal(num_el_per_cluster,
-                                      np.ones_like(num_el_per_cluster))
+        assert sorted(clusters) == [i for i in range(k)]
 
     def test_more_clusters_than_elements(self):
         # only the first m clusters should be initialized
         m = 10
         k = 20
         clusters = coclustering_dask._initialize_clusters(m, k)
-        num_el_per_cluster = clusters[:, :m].sum(axis=0)
-        np.testing.assert_array_equal(num_el_per_cluster,
-                                      np.ones_like(num_el_per_cluster))
+        assert set(clusters.compute().tolist()) == {i for i in range(m)}
 
 
 class TestCoclustering:

--- a/tests/test_coclustering_numpy.py
+++ b/tests/test_coclustering_numpy.py
@@ -25,25 +25,21 @@ class TestInitializeClusters:
         m = 10
         k = 3
         clusters = coclustering_numpy._initialize_clusters(m, k)
-        assert clusters.sum(axis=0).sum() == m
+        assert set(clusters.tolist()) == {i for i in range(k)}
 
     def test_all_clusters_are_initialized(self):
         # if m == k, all clusters should have initial occupation one
         m = 10
         k = 10
         clusters = coclustering_numpy._initialize_clusters(m, k)
-        num_el_per_cluster = clusters.sum(axis=0)
-        np.testing.assert_array_equal(num_el_per_cluster,
-                                      np.ones_like(num_el_per_cluster))
+        assert sorted(clusters) == [i for i in range(k)]
 
     def test_more_clusters_than_elements(self):
         # only the first m clusters should be initialized
         m = 10
         k = 20
         clusters = coclustering_numpy._initialize_clusters(m, k)
-        num_el_per_cluster = clusters[:, :m].sum(axis=0)
-        np.testing.assert_array_equal(num_el_per_cluster,
-                                      np.ones_like(num_el_per_cluster))
+        assert set(clusters.tolist()) == {i for i in range(m)}
 
 
 class TestCoclustering:

--- a/tests/test_triclustering.py
+++ b/tests/test_triclustering.py
@@ -10,8 +10,8 @@ from cgc.triclustering import Triclustering
 def triclustering():
     np.random.seed(1234)
     da.random.seed(1234)
-    d, m, n = 3, 4, 3
-    ncl_row, ncl_col, ncl_bnd = 2, 2, 2
+    d, m, n = 6, 10, 8
+    ncl_row, ncl_col, ncl_bnd = 5, 2, 3
     Z = np.random.randint(100, size=(d, m, n)).astype('float64')
     return Triclustering(Z, nclusters_row=ncl_row, nclusters_col=ncl_col,
                          nclusters_bnd=ncl_bnd, conv_threshold=1.e-5,
@@ -19,9 +19,20 @@ def triclustering():
 
 
 class TestTriclustering:
+    def test_check_initial_assignments(self, triclustering):
+        assert triclustering.row_clusters is None
+        assert triclustering.col_clusters is None
+        assert triclustering.bnd_clusters is None
+
     def test_run_with_threads(self, triclustering):
+        triclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                           [0, 1, 0, 1, 0, 1, 0, 1],
+                                           [0, 1, 2, 0, 1, 2])
         triclustering.run_with_threads(nthreads=2)
-        assert isinstance(triclustering.row_clusters, np.ndarray)
-        assert isinstance(triclustering.col_clusters, np.ndarray)
-        assert isinstance(triclustering.bnd_clusters, np.ndarray)
-        assert np.isclose(triclustering.error, -4638.9183068944785)
+        np.testing.assert_equal(triclustering.row_clusters,
+                                [1, 1, 0, 3, 4, 0, 2, 2, 0, 0])
+        np.testing.assert_equal(triclustering.col_clusters,
+                                [0, 1, 0, 1, 1, 1, 0, 1])
+        np.testing.assert_equal(triclustering.bnd_clusters,
+                                [1, 0, 2, 0, 1, 0])
+        assert np.isclose(triclustering.error, -69712.35398188536)


### PR DESCRIPTION
The cluster assignment for the co-/tri-clustering algorithms can be now specified as optional input. This improves the stability of the tests.  