### PR TITLE
Higher debug verbosity for co-/tri-clustering

### DIFF
--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -107,7 +107,6 @@ class Coclustering(object):
                 self.max_iterations,
                 self.epsilon
             )
-            e = e.compute()
             logger.info(f'Error = {e}')
             if converged:
                 logger.info(f'Run converged in {niters} iterations')

--- a/cgc/coclustering_numpy.py
+++ b/cgc/coclustering_numpy.py
@@ -1,4 +1,8 @@
+import logging
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 def _distance(Z, X, Y, epsilon):
@@ -41,6 +45,7 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon):
     Gavg = Z.mean()
 
     while (not converged) & (s < niters):
+        logger.debug(f'Iteration # {s} ..')
         # Calculate cluster based averages
         CoCavg = (np.dot(np.dot(R.T, Z), C) + Gavg * epsilon) / (
                 np.dot(np.dot(R.T, np.ones((m, n))), C) + epsilon)
@@ -63,7 +68,11 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon):
         # power 1 divergence, power 2 euclidean
         e = np.sum(np.power(minvals_da, 1))
 
+        logger.debug(f'Error = {e:+.15e}, dE = {e - old_e:+.15e}')
         converged = abs(e - old_e) < errobj
         s = s + 1
-
+    if converged:
+        logger.debug(f'Coclustering converged in {s} iterations')
+    else:
+        logger.debug(f'Coclustering not converged in {s} iterations')
     return converged, s, row_clusters, col_clusters, e

--- a/cgc/triclustering_numpy.py
+++ b/cgc/triclustering_numpy.py
@@ -1,4 +1,8 @@
+import logging
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 def _distance(Z, X, Y, epsilon):
@@ -52,6 +56,7 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
     converged = False
 
     while (not converged) & (s < niters):
+        logger.debug(f'Iteration # {s} ..')
         # Obtain all the cluster based averages
         CoCavg = (np.dot(np.dot(R.T, Y), C1) + Gavg * epsilon) / (
                 np.dot(np.dot(R.T, np.ones((m, n * d))), C1) + epsilon)
@@ -94,7 +99,11 @@ def triclustering(Z, nclusters_row, nclusters_col, nclusters_bnd, errobj,
         # power 1 divergence, power 2 euclidean
         e = sum(np.power(minvals, 1))
 
+        logger.debug(f'Error = {e:+.15e}, dE = {e - old_e:+.15e}')
         converged = abs(e - old_e) < errobj
         s = s + 1
-
+    if converged:
+        logger.debug(f'Triclustering converged in {s} iterations')
+    else:
+        logger.debug(f'Triclustering not converged in {s} iterations')
     return converged, s, row_clusters, col_clusters, bnd_clusters, e


### PR DESCRIPTION
More debug output is produced during the run of the co-/tri-clustering runs.