### PR TITLE
Fix solve increasing time with iterations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,35 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 [Unreleased]
 ************
 
+[0.1.2] - 2020-08-
+******************
+
+Fixed
+-----
+
+* Solve issue in increasingly large Dask graph for increasing iterations
+
+[0.1.1] - 2020-08-27
+********************
+
+Added
+-----
+
+* Cluster results of co-/tri-clustring are now serialized to a file
+
+Fixed
+-----
+
+* Improved output
+* Bug fix in selecting minimum error run in co- and tri-clustering
+
+Changed
+-------
+
+* K-means now loop over multiple k-values
+
 [0.1.0] - 2020-08-11
-************
+********************
 
 Added
 -----

--- a/cgc/coclustering_dask.py
+++ b/cgc/coclustering_dask.py
@@ -69,7 +69,8 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
         logger.debug(f'Iteration # {s} ..')
         # Calculate cluster based averages
         # dot is equivalent to:  da.dot(da.dot(R.T, da.ones((m, n))), C)
-        dot = da.dot(R.T.sum(axis=1, keepdims=True).repeat(n, axis=1), C)
+        dot = da.outer(da.bincount(row_clusters, minlength=nclusters_row),
+                       da.bincount(col_clusters, minlength=nclusters_col))
         CoCavg = (da.dot(da.dot(R.T, Z), C) + Gavg * epsilon) / (dot + epsilon)
 
         # Calculate distance based on row approximation

--- a/cgc/coclustering_dask.py
+++ b/cgc/coclustering_dask.py
@@ -85,9 +85,9 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
         minvals = da.min(d_col, axis=1)
         # power 1 divergence, power 2 euclidean
         e = da.sum(da.power(minvals, 1))
-        row_clusters, col_clusters, e = client.persist([row_clusters,
-                                                        col_clusters,
-                                                        e])
+        row_clusters, R, col_clusters, C, e = client.persist([row_clusters, R,
+                                                              col_clusters, C,
+                                                              e])
         if run_on_worker:
             # this is workaround for e.compute() for a function that runs
             # on a worker with multiple threads

--- a/cgc/coclustering_dask.py
+++ b/cgc/coclustering_dask.py
@@ -26,8 +26,7 @@ def _initialize_clusters(n_el, n_clusters):
 
 def _setup_cluster_matrix(n_clusters, cluster_idx):
     """ Set cluster occupation matrix """
-    # TODO: check if Z shape is larger than max int32?
-    return da.eye(n_clusters, dtype=np.int32)[cluster_idx]
+    return da.eye(n_clusters, dtype=np.bool)[cluster_idx]
 
 
 def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,

--- a/cgc/coclustering_dask.py
+++ b/cgc/coclustering_dask.py
@@ -51,9 +51,11 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
 
     [m, n] = Z.shape
 
-    row_clusters = row_clusters_init if row_clusters_init is not None \
+    row_clusters = da.array(row_clusters_init) \
+        if row_clusters_init is not None \
         else _initialize_clusters(m, nclusters_row)
-    col_clusters = col_clusters_init if col_clusters_init is not None \
+    col_clusters = da.array(col_clusters_init) \
+        if col_clusters_init is not None \
         else _initialize_clusters(n, nclusters_col)
     R = _setup_cluster_matrix(nclusters_row, row_clusters)
     C = _setup_cluster_matrix(nclusters_col, col_clusters)

--- a/tests/test_coclustering_dask.py
+++ b/tests/test_coclustering_dask.py
@@ -15,7 +15,7 @@ class TestDistance:
         X = da.ones((m, n))
         Y = da.random.randint(2, size=(n, k)).astype('float64')
         epsilon = 1.e-8
-        d = coclustering_dask._distance(Z, X, Y, epsilon)
+        d = coclustering_dask._distance(Z, Y, epsilon)
         assert isinstance(d, da.core.Array)
         assert d.shape == (m, k)
         assert ~np.any(np.isinf(d))


### PR DESCRIPTION
Solve issue of Dask graph becoming larger for increasing iteration number in Dask-based co-clustering.
Also, got rid of large one matrices, hopefully also reducing the memory footprint of the Dask implementation. 