### PR TITLE
Update coclustering.py

### DIFF
--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -40,8 +40,13 @@ class Coclustering(object):
         self.epsilon = epsilon
         self.output_filename = output_filename
 
+        self.client = None
+        
         self.row_clusters = None
         self.col_clusters = None
+        
+        self.error = None
+        self.nruns_completed = 0
         
     def _clean(self):
         self.error = None

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -41,13 +41,12 @@ class Coclustering(object):
         self.output_filename = output_filename
         self.client = None
 
+        self._clean()
+
+    def _clean(self):
         self.row_clusters = None
         self.col_clusters = None
 
-        self.error = None
-        self.nruns_completed = 0
-
-    def _clean(self):
         self.error = None
         self.nruns_completed = 0
 

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class CoclusteringResults(Results):
+    """
+    Contains results and metadata of a co-clustering calculation
+    """
     def reset(self):
         self.row_clusters_initial = None
         self.col_clusters_initial = None

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -40,12 +40,11 @@ class Coclustering(object):
         self.epsilon = epsilon
         self.output_filename = output_filename
 
-        self.client = None
-
         self.row_clusters = None
         self.col_clusters = None
+        
+    def _clean(self):
         self.error = None
-
         self.nruns_completed = 0
 
     def run_with_dask(self, client=None, low_memory=False):
@@ -55,6 +54,8 @@ class Coclustering(object):
         :param client: Dask client
         :param low_memory: if true, use a memory-conservative algorithm
         """
+        self._clean()
+        
         self.client = client if client is not None else Client()
 
         if low_memory:
@@ -70,6 +71,8 @@ class Coclustering(object):
 
         :param nthreads: number of threads
         """
+        self._clean()
+        
         with ThreadPoolExecutor(max_workers=nthreads) as executor:
             futures = {
                 executor.submit(coclustering_numpy.coclustering,
@@ -96,9 +99,6 @@ class Coclustering(object):
                     self.error = e
                 self.nruns_completed += 1
         self._write_clusters()
-
-    def run_serial(self):
-        raise NotImplementedError
 
     def _dask_runs_memory(self):
         """ Memory efficient Dask implementation: sequential runs """

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -116,7 +116,7 @@ class Coclustering(object):
                 r for r in range(self.nruns)
             }
             for future in concurrent.futures.as_completed(futures):
-                logger.info(f'Waiting for run {self.nruns_completed} ..')
+                logger.info(f'Retrieving run {self.results.nruns_completed}')
                 converged, niters, row, col, e = future.result()
                 logger.info(f'Error = {e}')
                 if converged:
@@ -180,7 +180,7 @@ class Coclustering(object):
                 futures,
                 with_results=True,
                 raise_errors=False):
-            logger.info(f'Waiting for run {self.nruns_completed} ..')
+            logger.info(f'Retrieving run {self.results.nruns_completed} ..')
             converged, niters, row, col, e = result
             logger.info(f'Error = {e}')
             if converged:

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -50,14 +50,15 @@ class Coclustering(object):
         self.error = None
         self.nruns_completed = 0
 
-    def run_with_dask(self, client=None, low_memory=False, row_clusters=None, col_clusters=None):
+    def run_with_dask(self, client=None, low_memory=False,
+                      row_clusters=None, col_clusters=None):
         """
         Run the co-clustering with Dask
 
         :param client: Dask client
         :param low_memory: if true, use a memory-conservative algorithm
         :param row_clusters: initial row clusters
-        :param col_clusters: initial column clusters        
+        :param col_clusters: initial column clusters
         """
         self._clean(row_clusters, col_clusters)
 
@@ -69,7 +70,8 @@ class Coclustering(object):
             self._dask_runs_performance()
         self._write_clusters()
 
-    def run_with_threads(self, nthreads=1, row_clusters=None, col_clusters=None):
+    def run_with_threads(self, nthreads=1,
+                         row_clusters=None, col_clusters=None):
         """
         Run the co-clustering using an algorithm based on numpy + threading
         (only suitable for local runs)

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -39,15 +39,14 @@ class Coclustering(object):
         self.nruns = nruns
         self.epsilon = epsilon
         self.output_filename = output_filename
-
         self.client = None
-        
+
         self.row_clusters = None
         self.col_clusters = None
-        
+
         self.error = None
         self.nruns_completed = 0
-        
+
     def _clean(self):
         self.error = None
         self.nruns_completed = 0
@@ -60,7 +59,7 @@ class Coclustering(object):
         :param low_memory: if true, use a memory-conservative algorithm
         """
         self._clean()
-        
+
         self.client = client if client is not None else Client()
 
         if low_memory:
@@ -77,7 +76,7 @@ class Coclustering(object):
         :param nthreads: number of threads
         """
         self._clean()
-        
+
         with ThreadPoolExecutor(max_workers=nthreads) as executor:
             futures = {
                 executor.submit(coclustering_numpy.coclustering,

--- a/cgc/results.py
+++ b/cgc/results.py
@@ -5,15 +5,28 @@ from . import __version__
 
 
 class Results(object):
+    """
+    Base class to be inherited by the various calculators. It is meant to
+    contain results and metadata of a calculation.
+    """
     def __init__(self):
         self.version = __version__
         self.time_created = datetime.datetime.now().isoformat()
         self.reset()
 
     def reset(self):
+        """
+        The attributes and their default value can be defined in the reset
+        method.
+        """
         pass
 
     def write(self, filename=''):
+        """
+        Serialize the object attributes in a JSON file.
+
+        :param filename:
+        """
         if filename:
             with open(filename, 'w') as f:
                 json.dump(self.__dict__, f, indent=4)

--- a/cgc/results.py
+++ b/cgc/results.py
@@ -1,0 +1,23 @@
+import datetime
+import json
+
+from . import __version__
+
+
+class Results(object):
+    def __init__(self):
+        self.version = __version__
+        self.time_created = datetime.datetime.now().isoformat()
+        self.reset()
+
+    def reset(self):
+        pass
+
+    def write(self, filename=''):
+        if filename:
+            with open(filename, 'w') as f:
+                json.dump(self.__dict__, f, indent=4)
+
+    def __setattr__(self, name, value):
+        self.__dict__['time_updated'] = datetime.datetime.now().isoformat()
+        self.__dict__[name] = value

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -13,54 +13,54 @@ def coclustering():
     ncl_row, ncl_col = 5, 2
     Z = np.random.randint(100, size=(m, n)).astype('float64')
     return Coclustering(Z, nclusters_row=ncl_row, nclusters_col=ncl_col,
-                        conv_threshold=1.e-5, max_iterations=100, nruns=10,
+                        conv_threshold=1.e-5, max_iterations=100, nruns=1,
                         epsilon=1.e-8)
 
 
 class TestCoclustering:
     def test_check_initial_assignments(self, coclustering):
-        assert coclustering.row_clusters is None
-        assert coclustering.col_clusters is None
+        assert coclustering.results.row_clusters is None
+        assert coclustering.results.col_clusters is None
 
     def test_run_with_threads(self, coclustering):
         coclustering.run_with_threads(nthreads=2,
                                       row_clusters=[0, 1, 2, 3, 4,
                                                     0, 1, 2, 3, 4],
                                       col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
-        np.testing.assert_equal(coclustering.row_clusters,
+        np.testing.assert_equal(coclustering.results.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
-        np.testing.assert_equal(coclustering.col_clusters,
+        np.testing.assert_equal(coclustering.results.col_clusters,
                                 [0, 0, 0, 1, 0, 0, 1, 1])
-        assert np.isclose(coclustering.error, -11554.1406004284)
+        assert np.isclose(coclustering.results.error, -11554.1406004284)
 
     def test_dask_runs_memory(self, client, coclustering):
         coclustering.run_with_dask(low_memory=True,
                                    row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
                                    col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
-        np.testing.assert_equal(coclustering.row_clusters,
+        np.testing.assert_equal(coclustering.results.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
-        np.testing.assert_equal(coclustering.col_clusters,
+        np.testing.assert_equal(coclustering.results.col_clusters,
                                 [0, 0, 0, 1, 0, 0, 1, 1])
-        assert np.isclose(coclustering.error, -11554.1406004284)
+        assert np.isclose(coclustering.results.error, -11554.1406004284)
 
     def test_dask_runs_performance(self, client, coclustering):
         coclustering.run_with_dask(client=client, low_memory=False,
                                    row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
                                    col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
-        np.testing.assert_equal(coclustering.row_clusters,
+        np.testing.assert_equal(coclustering.results.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
-        np.testing.assert_equal(coclustering.col_clusters,
+        np.testing.assert_equal(coclustering.results.col_clusters,
                                 [0, 0, 0, 1, 0, 0, 1, 1])
-        assert np.isclose(coclustering.error, -11554.1406004284)
+        assert np.isclose(coclustering.results.error, -11554.1406004284)
 
     def test_nruns_completed_threads(self, coclustering):
         coclustering.run_with_threads(nthreads=1)
-        assert coclustering.nruns_completed == 10
+        assert coclustering.results.nruns_completed == 1
         coclustering.run_with_threads(nthreads=1)
-        assert coclustering.nruns_completed == 10
+        assert coclustering.results.nruns_completed == 2
 
     def test_nruns_completed_dask(self, client, coclustering):
         coclustering.run_with_dask(client)
-        assert coclustering.nruns_completed == 10
+        assert coclustering.results.nruns_completed == 1
         coclustering.run_with_dask(client, low_memory=True)
-        assert coclustering.nruns_completed == 10
+        assert coclustering.results.nruns_completed == 2

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -24,8 +24,9 @@ class TestCoclustering:
 
     def test_run_with_threads(self, coclustering):
         coclustering.run_with_threads(nthreads=2,
-                                      row_clusters=[0,1,2,3,4,0,1,2,3,4],
-                                      col_clusters=[0,1,0,1,0,1,0,1])
+                                      row_clusters=[0, 1, 2, 3, 4,
+                                                    0, 1, 2, 3, 4],
+                                      col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -23,9 +23,10 @@ class TestCoclustering:
         assert coclustering.col_clusters is None
 
     def test_run_with_threads(self, coclustering):
-        coclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                          [0, 1, 0, 1, 0, 1, 0, 1])
-        coclustering.run_with_threads(nthreads=2)
+        coclustering.run_with_threads(nthreads=2,
+                                      row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                      col_clusters=[0, 1, 0, 1, 0, 1, 0, 1]
+                                     )
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,
@@ -33,9 +34,10 @@ class TestCoclustering:
         assert np.isclose(coclustering.error, -11554.1406004284)
 
     def test_dask_runs_memory(self, client, coclustering):
-        coclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                          [0, 1, 0, 1, 0, 1, 0, 1])
-        coclustering._dask_runs_memory()
+        coclustering.run_with_dask(low_memory=True,
+                                   row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1]
+                                  )
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,
@@ -43,10 +45,10 @@ class TestCoclustering:
         assert np.isclose(coclustering.error, -11554.1406004284)
 
     def test_dask_runs_performance(self, client, coclustering):
-        coclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                          [0, 1, 0, 1, 0, 1, 0, 1])
-        coclustering.client = client
-        coclustering._dask_runs_performance()
+        coclustering.run_with_dask(client=client, low_memory=False,
+                                   row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1]
+                                  )
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -57,10 +57,10 @@ class TestCoclustering:
         coclustering.run_with_threads(nthreads=1)
         assert coclustering.nruns_completed == 10
         coclustering.run_with_threads(nthreads=1)
-        assert coclustering.nruns_completed == 20
+        assert coclustering.nruns_completed == 10
 
     def test_nruns_completed_dask(self, client, coclustering):
         coclustering.run_with_dask(client)
         assert coclustering.nruns_completed == 10
         coclustering.run_with_dask(client, low_memory=True)
-        assert coclustering.nruns_completed == 20
+        assert coclustering.nruns_completed == 10

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -24,9 +24,8 @@ class TestCoclustering:
 
     def test_run_with_threads(self, coclustering):
         coclustering.run_with_threads(nthreads=2,
-                                      row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                      col_clusters=[0, 1, 0, 1, 0, 1, 0, 1]
-                                     )
+                                      row_clusters=[0,1,2,3,4,0,1,2,3,4],
+                                      col_clusters=[0,1,0,1,0,1,0,1])
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,
@@ -36,8 +35,7 @@ class TestCoclustering:
     def test_dask_runs_memory(self, client, coclustering):
         coclustering.run_with_dask(low_memory=True,
                                    row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1]
-                                  )
+                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,
@@ -47,8 +45,7 @@ class TestCoclustering:
     def test_dask_runs_performance(self, client, coclustering):
         coclustering.run_with_dask(client=client, low_memory=False,
                                    row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1]
-                                  )
+                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
         np.testing.assert_equal(coclustering.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.col_clusters,

--- a/tests/test_coclustering_dask.py
+++ b/tests/test_coclustering_dask.py
@@ -12,7 +12,6 @@ class TestDistance:
         k = 2
         da.random.seed(1234)
         Z = da.random.randint(100, size=(m, n)).astype('float64')
-        X = da.ones((m, n))
         Y = da.random.randint(2, size=(n, k)).astype('float64')
         epsilon = 1.e-8
         d = coclustering_dask._distance(Z, Y, epsilon)


### PR DESCRIPTION
- Added private clean() method to reset error, initial clusters, and number of runs completed, so that successive run_xxx() methods work properly. Otherwise they return immediately if previously calculated error is smaller than the threshold and they also start from previous clusters, which may not be optimum.

- Removed run_serial() method, which is not implemented and not in use.