### PR TITLE
Input in result object

### DIFF
--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -108,7 +108,7 @@ class Coclustering(object):
         :return: co-clustering results
         """
         with ThreadPoolExecutor(max_workers=nthreads) as executor:
-            futures = {
+            futures = [
                 executor.submit(coclustering_numpy.coclustering,
                                 self.Z,
                                 self.nclusters_row,
@@ -119,9 +119,9 @@ class Coclustering(object):
                                 low_memory,
                                 numba_jit,
                                 row_clusters_init=self.row_clusters_init,
-                                col_clusters_init=self.col_clusters_init):
-                r for r in range(self.nruns)
-            }
+                                col_clusters_init=self.col_clusters_init)
+                for _ in range(self.nruns)
+            ]
             for future in concurrent.futures.as_completed(futures):
                 logger.info(f'Retrieving run {self.results.nruns_completed}')
                 converged, niters, row, col, e = future.result()

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -105,6 +105,9 @@ class Coclustering(object):
         (only suitable for local runs)
 
         :param nthreads: number of threads
+        :param low_memory: if true, use a memory-conservative algorithm
+        :param numba_jit: if true, and low_memory is true, then use Numba
+                          just-in-time compilation to improve performance
         :return: co-clustering results
         """
         with ThreadPoolExecutor(max_workers=nthreads) as executor:

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -128,8 +128,8 @@ class Coclustering(object):
                 else:
                     logger.warning(f'Run not converged in {niters} iterations')
                 if self.results.error is None or e < self.results.error:
-                    self.results.row_clusters = row.tolist()
-                    self.results.col_clusters = col.tolist()
+                    self.results.row_clusters = row
+                    self.results.col_clusters = col
                     self.results.error = e
                 self.results.nruns_completed += 1
         self.results.write(filename=self.output_filename)
@@ -156,8 +156,8 @@ class Coclustering(object):
             else:
                 logger.warning(f'Run not converged in {niters} iterations')
             if self.results.error is None or e < self.results.error:
-                self.results.row_clusters = row.compute().tolist()
-                self.results.col_clusters = col.compute().tolist()
+                self.results.row_clusters = row.compute()
+                self.results.col_clusters = col.compute()
                 self.results.error = e
             self.results.nruns_completed += 1
 
@@ -192,7 +192,7 @@ class Coclustering(object):
             else:
                 logger.warning(f'Run not converged in {niters} iterations')
             if self.results.error is None or e < self.results.error:
-                self.results.row_clusters = row.compute().tolist()
-                self.results.col_clusters = col.compute().tolist()
+                self.results.row_clusters = row.compute()
+                self.results.col_clusters = col.compute()
                 self.results.error = e
             self.results.nruns_completed += 1

--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -44,8 +44,8 @@ class Coclustering(object):
         :param nruns: number of differently-initialized runs
         :param epsilon: numerical parameter, avoids zero arguments in log
         :param output_filename: name of the file where to write the clusters
-        :param row_clusters: initial row clusters
-        :param col_clusters: initial column clusters
+        :param row_clusters_init: initial row clusters
+        :param col_clusters_init: initial column clusters
         """
         # Input parameters -----------------
         self.nclusters_row = nclusters_row

--- a/cgc/coclustering_dask.py
+++ b/cgc/coclustering_dask.py
@@ -69,10 +69,16 @@ def coclustering(Z, nclusters_row, nclusters_col, errobj, niters, epsilon,
     while (not converged) & (s < niters):
         logger.debug(f'Iteration # {s} ..')
         # Calculate cluster based averages
-        # dot is equivalent to:  da.dot(da.dot(R.T, da.ones((m, n))), C)
-        dot = da.outer(da.bincount(row_clusters, minlength=nclusters_row),
-                       da.bincount(col_clusters, minlength=nclusters_col))
-        CoCavg = (da.dot(da.dot(R.T, Z), C) + Gavg * epsilon) / (dot + epsilon)
+        # nel_clusters is a matrix with the number of elements per co-cluster
+        # originally computed as:  da.dot(da.dot(R.T, da.ones((m, n))), C)
+        nel_row_clusters = da.bincount(row_clusters, minlength=nclusters_row)
+        nel_col_clusters = da.bincount(col_clusters, minlength=nclusters_col)
+        logger.debug('num of populated clusters: row {}, col {}'.format(
+                        da.sum(nel_row_clusters > 0).compute(),
+                        da.sum(nel_col_clusters > 0).compute()))
+        nel_clusters = da.outer(nel_row_clusters, nel_col_clusters)
+        CoCavg = (da.dot(da.dot(R.T, Z), C) + Gavg * epsilon) / \
+                 (nel_clusters + epsilon)
 
         # Calculate distance based on row approximation
         d_row = _distance(Z, da.dot(C, CoCavg.T), epsilon)

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -14,6 +14,7 @@ class KmeansResults(Results):
     """
     def reset(self):
         self.k_value = None
+        self.var_list = None
         self.cl_mean_centroids = None
 
 
@@ -86,6 +87,8 @@ class Kmeans(object):
         and compute the sum of variances of each k.
         Finally select the smallest k which gives
         the sum of variances smaller than the threshold.
+
+        :return: k-means result object
         """
         # Get statistic measures
         self._compute_statistic_measures()
@@ -100,7 +103,7 @@ class Kmeans(object):
             var_list = np.hstack((var_list, self._compute_sum_var(kmeans_cc)))
             kmeans_cc_list.append(kmeans_cc)
         idx_k = min(np.where(var_list < self.var_thres)[0])
-        self.var_list = var_list
+        self.results.var_list = var_list
         self.results.k_value = self.k_range[idx_k]
         self.kmeans_cc = kmeans_cc_list[idx_k]
         del kmeans_cc_list
@@ -179,27 +182,30 @@ class Kmeans(object):
         """
         Export elbow curve plot
         """
-        plt.plot(self.k_range, self.var_list)  # kmean curve
-        plt.plot([min(self.k_range), max(self.k_range)],
-                 [self.var_thres, self.var_thres],
+        k_range = self.results.input_parameters['k_range']
+        var_thres = self.results.input_parameters['var_thres']
+        plt.plot(k_range, self.results.var_list)  # kmean curve
+        plt.plot([min(k_range), max(k_range)],
+                 [var_thres, var_thres],
                  color='r',
                  linestyle='--')  # Threshold
         plt.plot([self.results.k_value, self.results.k_value],
-                 [min(self.var_list), max(self.var_list)],
+                 [min(self.results.var_list), max(self.results.var_list)],
                  color='g',
                  linestyle='--')  # Selected k
-        xtick_step = int((max(self.k_range) - min(self.k_range)) / 6)
-        ytick_step = int((max(self.var_list) - min(self.var_list)) / 6)
-        plt.xticks(range(min(self.k_range), max(self.k_range), xtick_step))
-        plt.xlim(min(self.k_range), max(self.k_range))
-        plt.ylim(min(self.var_list), max(self.var_list))
-        plt.text(max(self.k_range) - 2 * xtick_step,
-                 self.var_thres + ytick_step / 4,
-                 'threshold={}'.format(self.var_thres),
+        xtick_step = int((max(k_range) - min(k_range)) / 6)
+        ytick_step = int((max(self.results.var_list)
+                          - min(self.results.var_list)) / 6)
+        plt.xticks(range(min(k_range), max(k_range), xtick_step))
+        plt.xlim(min(k_range), max(k_range))
+        plt.ylim(min(self.results.var_list), max(self.results.var_list))
+        plt.text(max(k_range) - 2 * xtick_step,
+                 var_thres + ytick_step / 4,
+                 'threshold={}'.format(var_thres),
                  color='r',
                  fontsize=12)
         plt.text(self.results.k_value + xtick_step / 4,
-                 max(self.var_list) - ytick_step,
+                 max(self.results.var_list) - ytick_step,
                  'k={}'.format(self.results.k_value),
                  color='g',
                  fontsize=12)

--- a/cgc/results.py
+++ b/cgc/results.py
@@ -18,9 +18,10 @@ class Results(object):
     Base class to be inherited by the various calculators. It is meant to
     contain results and metadata of a calculation.
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.version = __version__
         self.time_created = datetime.datetime.now().isoformat()
+        self.input_parameters = {name: value for name, value in kwargs.items()}
         self.reset()
 
     def reset(self):

--- a/cgc/results.py
+++ b/cgc/results.py
@@ -1,7 +1,16 @@
 import datetime
 import json
 
+import numpy as np
+
 from . import __version__
+
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
 
 
 class Results(object):
@@ -29,7 +38,7 @@ class Results(object):
         """
         if filename:
             with open(filename, 'w') as f:
-                json.dump(self.__dict__, f, indent=4)
+                json.dump(self.__dict__, f, indent=4, cls=NumpyEncoder)
 
     def __setattr__(self, name, value):
         self.__dict__['time_updated'] = datetime.datetime.now().isoformat()

--- a/cgc/triclustering.py
+++ b/cgc/triclustering.py
@@ -1,13 +1,26 @@
 import concurrent.futures
-import json
 import logging
 
 from concurrent.futures import ThreadPoolExecutor
 
-from . import __version__
 from . import triclustering_numpy
 
+from .results import Results
+
 logger = logging.getLogger(__name__)
+
+
+class TriclusteringResults(Results):
+    """
+    Contains results and metadata of a tri-clustering calculation
+    """
+    def reset(self):
+        self.row_clusters = None
+        self.col_clusters = None
+        self.bnd_clusters = None
+        self.error = None
+        self.nruns_completed = 0
+        self.nruns_converged = 0
 
 
 class Triclustering(object):
@@ -16,7 +29,8 @@ class Triclustering(object):
     """
     def __init__(self, Z, nclusters_row, nclusters_col, nclusters_bnd,
                  conv_threshold=1.e-5, max_iterations=1, nruns=1,
-                 epsilon=1.e-8, output_filename=''):
+                 epsilon=1.e-8, output_filename='', row_clusters_init=None,
+                 col_clusters_init=None, bnd_clusters_init=None):
         """
         Initialize the object
 
@@ -29,8 +43,11 @@ class Triclustering(object):
         :param nruns: number of differntly-initialized runs
         :param epsilon: numerical parameter, avoids zero arguments in log
         :param output_filename: name of the file where to write the clusters
+        :param row_clusters_init: initial row clusters
+        :param col_clusters_init: initial column clusters
+        :param bnd_clusters_init: initial band clusters
         """
-        self.Z = Z
+        # Input parameters -----------------
         self.nclusters_row = nclusters_row
         self.nclusters_col = nclusters_col
         self.nclusters_bnd = nclusters_bnd
@@ -39,15 +56,24 @@ class Triclustering(object):
         self.nruns = nruns
         self.epsilon = epsilon
         self.output_filename = output_filename
+        self.row_clusters_init = row_clusters_init
+        self.col_clusters_init = col_clusters_init
+        self.bnd_clusters_init = bnd_clusters_init
+        # Input parameters end -------------
 
-        self.client = None
+        # store input parameters in results object
+        self.results = TriclusteringResults(**self.__dict__)
 
-        self.row_clusters = None
-        self.col_clusters = None
-        self.bnd_clusters = None
-        self.error = None
+        assert Z.ndim == 3, 'Incorrect dimensionality for Z matrix'
+        self.Z = Z
 
-        self.nruns_completed = 0
+        if all([cls is not None for cls in [row_clusters_init,
+                                            col_clusters_init,
+                                            bnd_clusters_init]]):
+            assert nruns == 1, 'Only nruns = 1 for given initial clusters'
+            assert Z.shape == (len(bnd_clusters_init),
+                               len(row_clusters_init),
+                               len(col_clusters_init))
 
     def run_with_threads(self, nthreads=1):
         """
@@ -55,6 +81,7 @@ class Triclustering(object):
         (only suitable for local runs)
 
         :param nthreads: number of threads
+        :return: tri-clustering results
         """
         with ThreadPoolExecutor(max_workers=nthreads) as executor:
             futures = {
@@ -66,60 +93,31 @@ class Triclustering(object):
                                 self.conv_threshold,
                                 self.max_iterations,
                                 self.epsilon,
-                                row_clusters_init=self.row_clusters,
-                                col_clusters_init=self.col_clusters,
-                                bnd_clusters_init=self.bnd_clusters
+                                row_clusters_init=self.row_clusters_init,
+                                col_clusters_init=self.col_clusters_init,
+                                bnd_clusters_init=self.bnd_clusters_init
                                 ):
                 r for r in range(self.nruns)
             }
             for future in concurrent.futures.as_completed(futures):
-                logger.info(f'Waiting for run {self.nruns_completed} ..')
+                logger.info(f'Waiting for run {self.results.nruns_completed}')
                 converged, niters, row, col, bnd, e = future.result()
                 logger.info(f'Error = {e}')
                 if converged:
                     logger.info(f'Run converged in {niters} iterations')
                 else:
                     logger.warning(f'Run not converged in {niters} iterations')
-                if self.error is None or e < self.error:
-                    self.row_clusters = row
-                    self.col_clusters = col
-                    self.bnd_clusters = bnd
-                    self.error = e
-                self.nruns_completed += 1
-        self._write_clusters()
+                if self.results.error is None or e < self.results.error:
+                    self.results.row_clusters = row
+                    self.results.col_clusters = col
+                    self.results.bnd_clusters = bnd
+                    self.results.error = e
+                self.results.nruns_completed += 1
+        self.results.write(filename=self.output_filename)
+        return self.results
 
     def run_with_dask(self, client=None):
         raise NotImplementedError
 
     def run_serial(self):
         raise NotImplementedError
-
-    def set_initial_clusters(self, row_clusters, col_clusters, bnd_clusters):
-        """
-        Set initial cluster assignment
-
-        :param row_clusters: initial row clusters
-        :param col_clusters: initial column clusters
-        :param bnd_clusters: initial band clusters
-        """
-        if (not (row_clusters is None
-                 and col_clusters is None
-                 and bnd_clusters is None)
-                and self.nruns > 1):
-            logging.warning('Multiple runs with the same cluster '
-                            'initialization will be performed.')
-        self.row_clusters = row_clusters
-        self.col_clusters = col_clusters
-        self.bnd_clusters = bnd_clusters
-
-    def _write_clusters(self):
-        if self.output_filename:
-            with open(self.output_filename, 'w') as f:
-                data = {
-                    'cgc_version': __version__,
-                    'error': self.error,
-                    'row_clusters': self.row_clusters.tolist(),
-                    'col_clusters': self.col_clusters.tolist(),
-                    'bnd_clusters': self.bnd_clusters.tolist()
-                }
-                json.dump(data, f, indent=4)

--- a/tests/test_coclustering.py
+++ b/tests/test_coclustering.py
@@ -14,7 +14,10 @@ def coclustering():
     Z = np.random.randint(100, size=(m, n)).astype('float64')
     return Coclustering(Z, nclusters_row=ncl_row, nclusters_col=ncl_col,
                         conv_threshold=1.e-5, max_iterations=100, nruns=1,
-                        epsilon=1.e-8)
+                        epsilon=1.e-8,
+                        row_clusters_init=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                        col_clusters_init=[0, 1, 0, 1, 0, 1, 0, 1]
+                        )
 
 
 class TestCoclustering:
@@ -23,10 +26,7 @@ class TestCoclustering:
         assert coclustering.results.col_clusters is None
 
     def test_run_with_threads(self, coclustering):
-        coclustering.run_with_threads(nthreads=2,
-                                      row_clusters=[0, 1, 2, 3, 4,
-                                                    0, 1, 2, 3, 4],
-                                      col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
+        coclustering.run_with_threads(nthreads=2)
         np.testing.assert_equal(coclustering.results.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.results.col_clusters,
@@ -34,9 +34,7 @@ class TestCoclustering:
         assert np.isclose(coclustering.results.error, -11554.1406004284)
 
     def test_dask_runs_memory(self, client, coclustering):
-        coclustering.run_with_dask(low_memory=True,
-                                   row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
+        coclustering.run_with_dask(low_memory=True)
         np.testing.assert_equal(coclustering.results.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.results.col_clusters,
@@ -44,9 +42,7 @@ class TestCoclustering:
         assert np.isclose(coclustering.results.error, -11554.1406004284)
 
     def test_dask_runs_performance(self, client, coclustering):
-        coclustering.run_with_dask(client=client, low_memory=False,
-                                   row_clusters=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                   col_clusters=[0, 1, 0, 1, 0, 1, 0, 1])
+        coclustering.run_with_dask(client=client, low_memory=False)
         np.testing.assert_equal(coclustering.results.row_clusters,
                                 [3, 0, 1, 4, 0, 2, 2, 2, 3, 4])
         np.testing.assert_equal(coclustering.results.col_clusters,

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -66,9 +66,9 @@ class TestKmeans(unittest.TestCase):
     def test_statistic_centroids_shape(self):
         km = initialize_kmean()
         km.compute()
-        self.assertEqual((3, 2), km.cl_mean_centroids.shape)
+        self.assertEqual((3, 2), km.results.cl_mean_centroids.shape)
 
     def test_centroids_nan(self):
         km = initialize_kmean()
         km.compute()
-        self.assertTrue(all(np.isnan(km.cl_mean_centroids[2, :])))
+        self.assertTrue(all(np.isnan(km.results.cl_mean_centroids[2, :])))

--- a/tests/test_triclustering.py
+++ b/tests/test_triclustering.py
@@ -15,30 +15,30 @@ def triclustering():
     Z = np.random.randint(100, size=(d, m, n)).astype('float64')
     return Triclustering(Z, nclusters_row=ncl_row, nclusters_col=ncl_col,
                          nclusters_bnd=ncl_bnd, conv_threshold=1.e-5,
-                         max_iterations=100, nruns=10, epsilon=1.e-8)
+                         max_iterations=100, nruns=1, epsilon=1.e-8,
+                         row_clusters_init=[0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+                         col_clusters_init=[0, 1, 0, 1, 0, 1, 0, 1],
+                         bnd_clusters_init=[0, 1, 2, 0, 1, 2])
 
 
 class TestTriclustering:
     def test_check_initial_assignments(self, triclustering):
-        assert triclustering.row_clusters is None
-        assert triclustering.col_clusters is None
-        assert triclustering.bnd_clusters is None
+        assert triclustering.results.row_clusters is None
+        assert triclustering.results.col_clusters is None
+        assert triclustering.results.bnd_clusters is None
 
     def test_run_with_threads(self, triclustering):
-        triclustering.set_initial_clusters([0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
-                                           [0, 1, 0, 1, 0, 1, 0, 1],
-                                           [0, 1, 2, 0, 1, 2])
         triclustering.run_with_threads(nthreads=2)
-        np.testing.assert_equal(triclustering.row_clusters,
+        np.testing.assert_equal(triclustering.results.row_clusters,
                                 [1, 1, 0, 3, 4, 0, 2, 2, 0, 0])
-        np.testing.assert_equal(triclustering.col_clusters,
+        np.testing.assert_equal(triclustering.results.col_clusters,
                                 [0, 1, 0, 1, 1, 1, 0, 1])
-        np.testing.assert_equal(triclustering.bnd_clusters,
+        np.testing.assert_equal(triclustering.results.bnd_clusters,
                                 [1, 0, 2, 0, 1, 0])
-        assert np.isclose(triclustering.error, -69712.35398188536)
+        assert np.isclose(triclustering.results.error, -69712.35398188536)
 
     def test_nruns_completed(self, triclustering):
         triclustering.run_with_threads(nthreads=1)
-        assert triclustering.nruns_completed == 10
+        assert triclustering.results.nruns_completed == 1
         triclustering.run_with_threads(nthreads=1)
-        assert triclustering.nruns_completed == 20
+        assert triclustering.results.nruns_completed == 2


### PR DESCRIPTION
All input parameters are now added to a dictionary in the results object. In this way one can take the result of a run and directly feed it into another object to repeat the calculation:
```python
cc = Coclustering(Z, ...)
results = cc.run_with_threads(2)  # get results of a 

cc_new = Coclustering(Z, **results.input_parameters)
```
I have moved the initial cluster assignments to the `__init__` so we don't have duplicate code in the numpy and dask methods, plus they can also be passed together with the other input parameters in the way shown above.
Any other metadata we might need to store in the results?
