### PR TITLE
make k-means initialisation more robust

### DIFF
--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -199,36 +199,39 @@ class Kmeans(object):
         """
         Export elbow curve plot
         """
-        k_range = self.results.input_parameters['k_range']
-        var_thres = self.results.input_parameters['var_thres']
-        plt.plot(k_range, self.results.var_list)  # kmean curve
-        plt.plot([min(k_range), max(k_range)],
-                 [var_thres, var_thres],
+        plt.plot(self.k_range, self.results.var_list, marker='o')
+        plt.plot([min(self.k_range), max(self.k_range)],
+                 [self.var_thres, self.var_thres],
                  color='r',
                  linestyle='--')  # Threshold
         plt.plot([self.results.k_value, self.results.k_value],
                  [min(self.results.var_list), max(self.results.var_list)],
                  color='g',
                  linestyle='--')  # Selected k
-        xtick_step = int((max(k_range) - min(k_range)) / 6)
-        ytick_step = int((max(self.results.var_list)
-                          - min(self.results.var_list)) / 6)
-        plt.xticks(range(min(k_range), max(k_range), xtick_step))
-        plt.xlim(min(k_range), max(k_range))
-        plt.ylim(min(self.results.var_list), max(self.results.var_list))
-        plt.text(max(k_range) - 2 * xtick_step,
-                 var_thres + ytick_step / 4,
-                 'threshold={}'.format(var_thres),
+        x_min, x_max = min(self.k_range), max(self.k_range)
+        y_min, y_max = min(self.results.var_list), max(self.results.var_list)
+        plt.xlim(x_min, x_max)
+        plt.ylim(y_min, y_max)
+        plt.text(0.7,
+                 min(
+                    (self.var_thres-y_min)/(y_max-y_min) + 0.1,
+                    0.9
+                 ),
+                 'threshold={}'.format(self.var_thres),
                  color='r',
-                 fontsize=12)
-        plt.text(self.results.k_value + xtick_step / 4,
-                 max(self.results.var_list) - ytick_step,
+                 fontsize=12,
+                 transform=plt.gca().transAxes)
+        plt.text(min(
+                    (self.results.k_value-x_min)/(x_max-x_min) + 0.1,
+                    0.9
+                 ),
+                 0.7,
                  'k={}'.format(self.results.k_value),
                  color='g',
-                 fontsize=12)
+                 fontsize=12,
+                 transform=plt.gca().transAxes)
         plt.xlabel('k value', fontsize=20)
         plt.ylabel('Sum of variance', fontsize=20)
-        plt.grid(True)
         plt.savefig(output_plot,
                     format='png',
                     transparent=True,

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -68,17 +68,24 @@ class Kmeans(object):
 
         self.Z = Z
 
-        if len(np.unique(row_clusters)) > n_row_clusters:
-            print('Setting "n_row_clusters" to {}, \
-            accoding to the number of unique elements in "row_clusters".'.
-                  format(len(np.unique(row_clusters))))
-            self.n_row_clusters = len(np.unique(row_clusters))
+        if not max(self.row_clusters) < self.n_row_clusters:
+            raise ValueError("row_clusters include labels >= n_row_clusters")
+        if not max(self.col_clusters) < self.n_col_clusters:
+            raise ValueError("col_clusters include labels >= n_col_clusters")
 
-        if len(np.unique(col_clusters)) > n_col_clusters:
-            print('Setting "col_clusters" to {}, \
-            accoding to the number of unique elements in "col_clusters".'.
-                  format(len(np.unique(col_clusters))))
-            self.n_col_clusters = len(np.unique(col_clusters))
+        if not min(self.k_range) > 0:
+            raise ValueError("All k-values in k_range must be > 0")
+
+        nonempty_row_cl = len(np.unique(self.row_clusters))
+        nonempty_col_cl = len(np.unique(self.col_clusters))
+        max_k = nonempty_row_cl * nonempty_col_cl
+        max_k_input = max(self.k_range)
+        if max_k_input > max_k:
+            raise ValueError("The maximum k-value exceeds the "
+                             "number of (non-empty) co-clusters")
+        elif max_k_input > max_k * 0.8:
+            logger.warning("k_range includes large k-values (80% "
+                           "of the number of co-clusters or more)")
 
     def compute(self):
         """

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -109,7 +109,11 @@ class Kmeans(object):
                 self.stat_measures_norm)
             var_list = np.hstack((var_list, self._compute_sum_var(kmeans_cc)))
             kmeans_cc_list.append(kmeans_cc)
-        idx_k = min(np.where(var_list < self.var_thres)[0])
+        idx_var_below_thres, = np.where(var_list < self.var_thres)
+        if len(idx_var_below_thres) == 0:
+            raise ValueError(f"No k-value has variance below "
+                             f"the threshold: {self.var_thres}")
+        idx_k = min(idx_var_below_thres, key=lambda x: self.k_range[x])
         self.results.var_list = var_list
         self.results.k_value = self.k_range[idx_k]
         self.kmeans_cc = kmeans_cc_list[idx_k]

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -38,6 +38,28 @@ def initialize_kmean():
 
 
 class TestKmeans(unittest.TestCase):
+    def test_kvalues_exceed_number_of_coclusters(self):
+        with self.assertRaises(ValueError):
+            Kmeans(
+                Z=np.random.random((6, 4)),
+                row_clusters=[0, 0, 1, 1, 2, 2],
+                col_clusters=[0, 0, 1, 1],
+                n_row_clusters=3,
+                n_col_clusters=2,
+                k_range=range(1, 8),
+            )
+
+    def test_kvalues_exceed_number_of_coclusters_populated(self):
+        with self.assertRaises(ValueError):
+            Kmeans(
+                Z=np.random.random((6, 4)),
+                row_clusters=[0, 0, 1, 1, 2, 2],
+                col_clusters=[0, 0, 1, 1],
+                n_row_clusters=4,
+                n_col_clusters=2,
+                k_range=range(1, 8),
+            )
+
     def test_kmean_force_n_clusters(self):
         Z = np.arange(20).reshape((5, 4))
         row_clusters = np.array([0, 0, 1, 1, 1])
@@ -72,3 +94,35 @@ class TestKmeans(unittest.TestCase):
         km = initialize_kmean()
         km.compute()
         self.assertTrue(all(np.isnan(km.results.cl_mean_centroids[2, :])))
+
+    def test_kvalue_does_not_depend_on_krange_order(self):
+        # 4 co-clusters, 2 clusters
+        Z = np.array([
+            [0, 0, 1],
+            [0, 0, 1],
+            [1, 1, 0]
+        ])
+        row_cluseters = np.array([0, 0, 1])
+        col_clusters = np.array([0, 0, 1])
+        km = Kmeans(
+            Z=Z,
+            row_clusters=row_cluseters,
+            col_clusters=col_clusters,
+            n_row_clusters=2,
+            n_col_clusters=2,
+            k_range=range(1, 5),
+            var_thres=2.0
+        )
+        res = km.compute()
+        self.assertEqual(res.k_value, 2)
+        km = Kmeans(
+            Z=Z,
+            row_clusters=row_cluseters,
+            col_clusters=col_clusters,
+            n_row_clusters=2,
+            n_col_clusters=2,
+            k_range=range(4, 0, -1),
+            var_thres=2.0
+        )
+        res = km.compute()
+        self.assertEqual(res.k_value, 2)

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -60,24 +60,6 @@ class TestKmeans(unittest.TestCase):
                 k_range=range(1, 8),
             )
 
-    def test_kmean_force_n_clusters(self):
-        Z = np.arange(20).reshape((5, 4))
-        row_clusters = np.array([0, 0, 1, 1, 1])
-        col_clusters = np.array([0, 1, 1, 2])
-        n_row_cluster, n_col_cluster = 1, 1
-        k_range = range(1, 3)
-        kmean_max_iter = 100
-        km = Kmeans(
-            Z=Z,
-            row_clusters=row_clusters,
-            col_clusters=col_clusters,
-            n_row_clusters=n_row_cluster,
-            n_col_clusters=n_col_cluster,
-            k_range=k_range,
-            kmean_max_iter=kmean_max_iter)
-        self.assertEqual(2, km.n_row_clusters)
-        self.assertEqual(3, km.n_col_clusters)
-
     def test_statistic_mesures_mean(self):
         km = initialize_kmean()
         km.compute()

--- a/tests/test_triclustering_dask.py
+++ b/tests/test_triclustering_dask.py
@@ -52,7 +52,8 @@ class TestInitializeClusters:
 class TestTriclustering:
     def test_small_matrix(self, client):
         np.random.seed(1234)
-        Z = np.random.permutation(da.arange(60)).reshape((3, 4, 5))
+        Z = np.random.permutation(np.arange(60)).reshape((3, 4, 5))
+        Z = da.from_array(Z)
         ncl_row = 3
         ncl_col = 4
         ncl_bnd = 2
@@ -88,11 +89,11 @@ class TestTriclustering:
             col_clusters_init=np.mod(np.arange(nel_col), ncl_col),
             bnd_clusters_init=np.mod(np.arange(nel_bnd), ncl_bnd)
         )
-        np.testing.assert_array_equal(np.sort(np.unique(row_cl)),
+        np.testing.assert_array_equal(np.sort(np.unique(row_cl.compute())),
                                       np.arange(ncl_row))
-        np.testing.assert_array_equal(np.sort(np.unique(col_cl)),
+        np.testing.assert_array_equal(np.sort(np.unique(col_cl.compute())),
                                       np.arange(ncl_col))
-        np.testing.assert_array_equal(np.sort(np.unique(bnd_cl)),
+        np.testing.assert_array_equal(np.sort(np.unique(bnd_cl.compute())),
                                       np.arange(ncl_bnd))
 
     def test_as_many_clusters_as_elements(self, client):


### PR DESCRIPTION
The following minor changes are applied in order to make k-means more robust:
* The values in `k_range` are checked, especially with respect to the number of (populated) co-clusters; a warning is raised if the user tries to set very large values of k (> 80% of the total number of co-clusters).
* An error is raised if the threshold on the variance is found to be too low, such that no k value gives a variance below the threshold. 
* A small modification of the algorithms fix a bug that would arise if the k_range would be set from the largest to the smallest values.

Some tests are added in order to make sure theses cases are checked.

I have also slightly modified the plotting function: setting some short k ranges lead to errors in the setting of the ticks for the axis. 