### PR TITLE
Kmean cluster labels

### DIFF
--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -15,8 +15,8 @@ class KmeansResults(Results):
 
     :var k_value: Optimal K value (value with maximum Silhouette score).
     :type k_value: int
-    :var km_labels: Refined clusters labels. It is a 2D- (for colustering)
-                    or 3D- (for triustering) array, with the shape of
+    :var km_labels: Refined clusters labels. It is a 2D- (for coclustering)
+                    or 3D- (for triclustering) array, with the shape of
                     `nclusters`. The value at location (band, row, column)
                     represents the refined cluster label of the corresponding
                     band/row/column cluster combination.

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -15,6 +15,12 @@ class KmeansResults(Results):
 
     :var k_value: Optimal K value (value with maximum Silhouette score).
     :type k_value: int
+    :var km_labels: Refined clusters labels. It is a 2D- (for colustering)
+                    or 3D- (for triustering) array, with the shape of
+                    `nclusters`. The value at location (band, row, column)
+                    represents the refined cluster label of the corresponding
+                    band/row/column cluster combination.
+    :type km_labels: np.ndarray
     :var measure_list: List of Silhouette coefficients for all tested k values.
     :type measure_list: np.ndarray
     :var cl_mean_centroids: Refined cluster averages computed as the centroids
@@ -23,6 +29,7 @@ class KmeansResults(Results):
     :type cl_mean_centroids: np.ndarray
     """
     k_value = None
+    km_labels = None
     measure_list = None
     cl_mean_centroids = None
 
@@ -183,6 +190,11 @@ class Kmeans(object):
         mask = np.zeros_like(self.results.cl_mean_centroids, dtype=bool)
         mask[tuple(indices)] = True
         self.results.cl_mean_centroids[mask] = cl_mean_centroids
+
+        # Make a lookup matrix from un-refined clusters to Kmean clusters
+        km_labels = np.full(self.nclusters, np.nan)
+        km_labels[mask] = self.kmean_cluster.labels_
+        self.results.km_labels = km_labels
 
         self.results.write(filename=self.output_filename)
         return self.results

--- a/docs/triclustering.rst
+++ b/docs/triclustering.rst
@@ -42,7 +42,8 @@ is setup by creating an instance of ``Triclustering``:
     )
 
 The input arguments of ``Triclustering`` are identical to the ``Coclustering`` ones (see :doc:`coclustering`) -
-``nclusters_bnd`` is the only additional argument, which sets the maximum number of clusters along the 'band' dimension.
+``nclusters_bnd`` is the only additional argument, which sets the maximum number of clusters along the 'band' dimension. 
+Note that a lower number of clusters can be identified by the algorithm (some of the clusters may remain empty).
 
 .. NOTE::
     The first axis of ``Z`` is assumed to represent the 'band' dimension.

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -4,14 +4,14 @@ import numpy as np
 from cgc.kmeans import Kmeans
 
 
-def init_cocluster():
+def init_cocluster_km():
     """
     Z:
         [[0, 0, 1, 1],
         [0, 0, 1, 1],
-        [2, 2, 3, 3],
-        [2, 2, 3, 3],
-        [2, 2, 3, 3]]
+        [1, 1, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 0, 0]]
 
     cluster index:
         [[(0,0), (0,0), (0,1), (0,1)],
@@ -20,8 +20,8 @@ def init_cocluster():
         [(1,0), (1,0), (1,1), (1,1)],
         [(1,0), (1,0), (1,1), (1,1)]]
     """
-    Z = np.array([[0, 0, 1, 1], [0, 0, 1, 1], [2, 2, 3, 3], [2, 2, 3, 3],
-                  [2, 2, 3, 3]])
+    Z = np.array([[0, 0, 1, 1], [0, 0, 1, 1], [1, 1, 0, 0], [1, 1, 0, 0],
+                  [1, 1, 0, 0]])
     row_clusters = np.array([0, 0, 1, 1, 1])
     col_clusters = np.array([0, 0, 1, 1])
     nrow_clusters, ncol_clusters = 3, 2  # 1 non populated row/col cluster
@@ -37,16 +37,17 @@ def init_cocluster():
     return km
 
 
-def init_tricluster():
-    Z1 = np.array([[0, 0, 1, 1], [0, 0, 1, 1], [2, 2, 3, 3], [2, 2, 3, 3],
-                   [2, 2, 3, 3]])
-    Z = np.dstack((Z1, Z1, Z1 + 1, Z1 + 1))
-    row_clusters = np.array([0, 0, 1, 1, 1])
+def init_tricluster_km():
+    Z1 = np.array([[0, 0, 1, 1], [0, 0, 1, 1], [1, 1, 0, 0]])
+    Z = np.full((4, 3, 4), 0)
+    Z[:2] = Z1
+    Z[2:] = Z1 + 1
+    row_clusters = np.array([0, 0, 1])
     col_clusters = np.array([0, 0, 1, 1])
     band_clusters = np.array([0, 0, 1, 1])
     nrow_clusters, ncol_clusters, nband_clusters = 2, 2, 2
-    clusters = [row_clusters, col_clusters, band_clusters]
-    nclusters = [nrow_clusters, ncol_clusters, nband_clusters]
+    clusters = [band_clusters, row_clusters, col_clusters]
+    nclusters = [nband_clusters, nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
     kmean_max_iter = 2
     km = Kmeans(Z=Z,
@@ -101,45 +102,70 @@ class TestKmeans(unittest.TestCase):
             )
 
     def test_statistic_coclustering(self):
-        km = init_cocluster()
+        km = init_cocluster_km()
         km._compute_statistic_measures()
         results = np.array([[0., 0., 0., 0., 0., 0.], [1., 0., 1., 1., 1., 1.],
-                            [2., 0., 2., 2., 2., 2.], [3., 0., 3., 3., 3.,
-                                                       3.]])
+                            [1., 0., 1., 1., 1., 1.], [0., 0., 0., 0., 0.,
+                                                       0.]])
         self.assertTrue(
             np.all(results == km.stat_measures))  # First colummn is mean
 
-    def test_kmeam_labels_coclustering(self):
-        km = init_cocluster()
+    def test_kmean_labels_coclustering(self):
+        km = init_cocluster_km()
         km.compute()
-        labels = km.kmean_cluster.labels_
-        self.assertTrue(labels.shape == (4, ))
-        self.assertEqual(labels[0], labels[1])
-        self.assertEqual(labels[2], labels[3])
+
+        cl_km_labels = km.results.km_labels  # Refined labels in clusters
+        row_clusters, col_clusters = np.meshgrid(km.clusters[0],
+                                                 km.clusters[1],
+                                                 indexing='ij')
+        Z_km_labels = cl_km_labels[row_clusters,
+                                   col_clusters]  # Refined labels in Z
+
+        # Check all values within the same refined cluster are the same
+        for k in range(km.results.k_value):
+            vk = km.Z[np.where(Z_km_labels == k)]
+            self.assertTrue(np.all(vk == vk[0]))
 
     def test_statistic_triclustering(self):
-        km = init_tricluster()
+        km = init_tricluster_km()
         km._compute_statistic_measures()
         results = np.array([[0., 0., 0., 0., 0., 0.], [1., 0., 1., 1., 1., 1.],
+                            [1., 0., 1., 1., 1., 1.], [0., 0., 0., 0., 0., 0.],
                             [1., 0., 1., 1., 1., 1.], [2., 0., 2., 2., 2., 2.],
-                            [2., 0., 2., 2., 2., 2.], [3., 0., 3., 3., 3., 3.],
-                            [3., 0., 3., 3., 3., 3.], [4., 0., 4., 4., 4.,
-                                                       4.]])
+                            [2., 0., 2., 2., 2., 2.], [1., 0., 1., 1., 1.,
+                                                       1.]])
         self.assertTrue(
             np.all(results == km.stat_measures))  # First colummn is mean
 
     def test_kvalues_triclustering(self):
-        km = init_tricluster()
+        km = init_tricluster_km()
         km.compute()
         self.assertEqual(km.results.k_value, 3)
 
+    def test_kmean_labels_triclustering(self):
+        km = init_tricluster_km()
+        km.compute()
+
+        cl_km_labels = km.results.km_labels  # Refined labels in clusters
+        band_clusters, row_clusters, col_clusters = np.meshgrid(km.clusters[0],
+                                                                km.clusters[1],
+                                                                km.clusters[2],
+                                                                indexing='ij')
+        Z_km_labels = cl_km_labels[band_clusters, row_clusters,
+                                   col_clusters]  # Refined labels in Z
+
+        # Check all values within the same refined cluster are the same
+        for k in range(km.results.k_value):
+            vk = km.Z[np.where(Z_km_labels == k)]
+            self.assertTrue(np.all(vk == vk[0]))
+
     def test_statistic_centroids_shape(self):
-        km = init_cocluster()
+        km = init_cocluster_km()
         km.compute()
         self.assertEqual((3, 2), km.results.cl_mean_centroids.shape)
 
     def test_centroids_nan(self):
-        km = init_cocluster()
+        km = init_cocluster_km()
         km.compute()
         self.assertTrue(all(np.isnan(km.results.cl_mean_centroids[2, :])))
 
@@ -162,3 +188,11 @@ class TestKmeans(unittest.TestCase):
                     k_range=range(3, 1, -1))
         res2 = km.compute()
         self.assertEqual(res2.k_value, 2)
+
+
+if __name__ == "__main__":
+    t = TestKmeans()
+    # t.test_kmean_labels_coclustering()
+    # t.test_kmean_labels_triclustering()
+    # t.test_statistic_coclustering()
+    t.test_statistic_triclustering()

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -188,11 +188,3 @@ class TestKmeans(unittest.TestCase):
                     k_range=range(3, 1, -1))
         res2 = km.compute()
         self.assertEqual(res2.k_value, 2)
-
-
-if __name__ == "__main__":
-    t = TestKmeans()
-    # t.test_kmean_labels_coclustering()
-    # t.test_kmean_labels_triclustering()
-    # t.test_statistic_coclustering()
-    t.test_statistic_triclustering()


### PR DESCRIPTION
Fix two issues: #57 and #52.

For issue #52, the K-mean label was added as an array with the shape of un-refined clusters. The value at location (band, row, column) represents the refined cluster label of the corresponding band/row/column cluster combination.

- [x] Mention empty clusters in tri-clustering doc.
- [x] Add K-mean labels as results
- [x] Update tests
- [ ] Update tutorial