### PR TITLE
Update test instructions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,8 @@ jobs:
           python --version
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Build
-        shell: bash -l {0}
-        run: |
-          python setup.py build
+          python -m pip install --upgrade pip setuptools
+          python -m pip install .[dev]
       - name: Test
-        shell: bash -l {0}
         run: |
-          pip install pytest pytest-cov pycodestyle
-          pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml
+          pytest -v

--- a/README.rst
+++ b/README.rst
@@ -76,11 +76,14 @@ Alternatively, you can clone this repository and install it using `pip`:
   pip install .
 
 
-Run tests (including coverage) with:
+In order to run tests (including coverage) install the `dev` package version:
 
 .. code-block:: console
 
-  python setup.py test
+  git clone https://github.com/phenology/cgc.git
+  cd cgc
+  pip install .[dev]
+  pytest -v
 
 Documentation
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,6 @@
 [metadata]
 description-file = README.rst
 
-[aliases]
-# Define `python setup.py test`
-test=pytest
-
 [coverage:run]
 branch = True
 source = cgc

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,11 @@ setup(
     ],
     test_suite='tests',
     install_requires=requirements,
-    setup_requires=[
-        # dependency for `python setup.py test`
-        'pytest-runner',
-    ],
-    tests_require=[
-        'pytest',
-        'pytest-cov',
-        'pycodestyle',
-    ]
+    extras_require={
+        'dev': [
+            'pytest',
+            'pytest-cov',
+            'pycodestyle',
+        ]
+    }
 )


### PR DESCRIPTION
Update test instructions, dropping the deprecated use of setuptools' test: https://setuptools.pypa.io/en/latest/userguide/commands.html?highlight=test#test-build-package-and-run-a-unittest-suite 