### PR TITLE
Improve k-means

### DIFF
--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -192,14 +192,15 @@ class Kmeans(object):
             label_sum = 0.
             label_n_elements = 0
             # Loop over all co-/tri-clusters in the selected refined cluster
-            clusters = np.where(km_labels == label)
-            for cluster in zip(*clusters):
-                idx = [np.where(self.clusters[i] == cluster[i])[0]
-                       for i in range(self.Z.ndim)]
-                label_n_elements += np.prod([len(idx_x) for idx_x in idx])
-                idx = np.meshgrid(*idx, indexing='ij')
-                label_sum += self.Z[tuple(idx)].sum()
-            cluster_averages[clusters] = label_sum / label_n_elements
+            clusters = np.nonzero(km_labels == label)
+            if all(len(c) > 0 for c in clusters):
+                for cluster in zip(*clusters):
+                    idx = [np.where(self.clusters[i] == cluster[i])[0]
+                           for i in range(self.Z.ndim)]
+                    label_n_elements += np.prod([len(idx_x) for idx_x in idx])
+                    idx = np.meshgrid(*idx, indexing='ij')
+                    label_sum += self.Z[tuple(idx)].sum()
+                cluster_averages[clusters] = label_sum / label_n_elements
         self.results.cluster_averages = cluster_averages
 
         self.results.write(filename=self.output_filename)

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -132,17 +132,22 @@ class Kmeans(object):
             logger.warning("k_range includes large k-values (80% "
                            "of the number of clusters or more)")
 
-    def compute(self):
+        self.stat_measures_norm = None
+
+    def compute(self, recalc_statistics=False):
         """
         Compute statistics for each clustering group. Then loop through the
         range of k values, and compute the averaged Silhouette measure of each
         k value. Finally select the k with the maximum Silhouette measure.
 
+        :param recalc_statistics: If True, always recompute statistics.
+        :type recalc_statistics: bool, optional
         :return: K-means results.
         :type: cgc.kmeans.KmeansResults
         """
-        # Get statistic measures
-        self._compute_statistic_measures()
+        # Compute statistics
+        if self.stat_measures_norm is None or recalc_statistics:
+            self._compute_statistic_measures()
 
         # Search for value k
         silhouette_avg_list = np.array([])  # average silhouette measure vs k

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -305,4 +305,3 @@ class TestKmeans(unittest.TestCase):
 
         assert run_kmeans() == 3
         assert run_kmeans((np.min,)) == 2
-

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -28,7 +28,7 @@ def init_cocluster_km():
     clusters = [row_clusters, col_clusters]
     nclusters = [nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmean_max_iter = 2
+    kmean_max_iter = 100
     km = Kmeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
@@ -131,6 +131,15 @@ class TestKmeans(unittest.TestCase):
                             [1., 0., 1., 1., 1., 1.], [0., 0., 0., 0., 0.,
                                                        0.]])
         self.assertTrue(np.all(results == km.stat_measures_norm))
+
+    def test_smaller_number_of_actual_clusters(self):
+        # should not fail even if the number of identified clusters is smaller
+        # than the number of required clusters
+        km = init_cocluster_km()
+        # there are 2 actual clusters
+        km.k_range = [3]
+        results = km.compute()
+        assert results.k_value == 3
 
     def test_kmean_labels_coclustering(self):
         km = init_cocluster_km()

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -250,3 +250,59 @@ class TestKmeans(unittest.TestCase):
                     k_range=range(3, 1, -1))
         res2 = km.compute()
         self.assertEqual(res2.k_value, 2)
+
+    def test_user_defined_statistics(self):
+        # use optional parameters for one of the statistics function
+        Z = np.array([[0, 0, 1, 1],
+                      [0, 0, 1, 1],
+                      [1, 1, 2, 2],
+                      [1, 1, 2, 2],
+                      [1, 1, 2, 2]])
+        row_clusters = np.array([0, 0, 1, 1, 1])
+        col_clusters = np.array([0, 0, 1, 1])
+        nrow_clusters, ncol_clusters = 2, 2
+        clusters = [row_clusters, col_clusters]
+        nclusters = [nrow_clusters, ncol_clusters]
+        k_range = [2, 3]
+        kmean_max_iter = 100
+        km = Kmeans(Z=Z,
+                    clusters=clusters,
+                    nclusters=nclusters,
+                    k_range=k_range,
+                    kmean_max_iter=kmean_max_iter,
+                    statistics=(np.mean, (np.std, {'axis': None})))
+        res = km.compute()
+        assert res.input_parameters["statistics"][0][0] == "mean"
+        assert len(res.input_parameters["statistics"][0][1]) == 0
+        assert res.input_parameters["statistics"][1][0] == "std"
+        assert len(res.input_parameters["statistics"][1][1]) == 1
+        assert res.k_value == 3
+
+    def test_check_values_with_user_defined_statistics(self):
+        # the choice of the statistics affects the results
+        Z = np.array([[0, 0, 1, 1],
+                      [0, 0, 0.5, 1],
+                      [1, 1, 2, 2],
+                      [1, 1, 2, 2],
+                      [1, 0.5, 2, 0.5]])
+        row_clusters = np.array([0, 0, 1, 1, 1])
+        col_clusters = np.array([0, 0, 1, 1])
+        nrow_clusters, ncol_clusters = 2, 2
+        clusters = [row_clusters, col_clusters]
+        nclusters = [nrow_clusters, ncol_clusters]
+        k_range = [2, 3]
+        kmean_max_iter = 100
+
+        def run_kmeans(statistics=None):
+            km = Kmeans(Z=Z,
+                        clusters=clusters,
+                        nclusters=nclusters,
+                        k_range=k_range,
+                        kmean_max_iter=kmean_max_iter,
+                        statistics=statistics)
+            res = km.compute()
+            return res.k_value
+
+        assert run_kmeans() == 3
+        assert run_kmeans((np.min,)) == 2
+


### PR DESCRIPTION
Some improvements to k-means, to facilitate experiments where we need to try out things. 
- [x] Do not recompute statistics if already there. If we want to modify the range of tested k values, we do not want to recompute the statistics over the co- or tri- clusters (which is the expensive part of the calculations). 
- [x] Allow for arbitrary functions in statistics. The user can specify the list of features  as callable functions, to be computed over all the elements that are grouped in one co- or try-cluster.