### PR TITLE
General fixes

### DIFF
--- a/cgc/coclustering.py
+++ b/cgc/coclustering.py
@@ -1,3 +1,4 @@
+import copy
 import concurrent.futures
 import dask.distributed
 import logging
@@ -123,7 +124,7 @@ class Coclustering(object):
             self._dask_runs_performance()
 
         self.results.write(filename=self.output_filename)
-        return self.results
+        return copy.copy(self.results)
 
     def run_with_threads(self, nthreads=1, low_memory=False):
         """
@@ -167,7 +168,7 @@ class Coclustering(object):
                     self.results.error = e
                 self.results.nruns_completed += 1
         self.results.write(filename=self.output_filename)
-        return self.results
+        return copy.copy(self.results)
 
     def _dask_runs_memory(self):
         """ Memory efficient Dask implementation: sequential runs. """

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import logging
 from sklearn.cluster import KMeans
@@ -198,7 +199,7 @@ class Kmeans(object):
         self.results.cluster_averages = cluster_averages
 
         self.results.write(filename=self.output_filename)
-        return self.results
+        return copy.copy(self.results)
 
     def _compute_statistic_measures(self):
         """

--- a/cgc/triclustering.py
+++ b/cgc/triclustering.py
@@ -1,3 +1,4 @@
+import copy
 import concurrent.futures
 import logging
 
@@ -157,7 +158,7 @@ class Triclustering(object):
                     self.results.error = e
                 self.results.nruns_completed += 1
         self.results.write(filename=self.output_filename)
-        return self.results
+        return copy.copy(self.results)
 
     def run_with_dask(self, client=None):
         """
@@ -172,7 +173,7 @@ class Triclustering(object):
         self.client = client if client is not None else Client()
         self._dask_runs_memory()
         self.results.write(filename=self.output_filename)
-        return self.results
+        return copy.copy(self.results)
 
     def _dask_runs_memory(self):
         """ Memory efficient Dask implementation: sequential runs """

--- a/cgc/utils.py
+++ b/cgc/utils.py
@@ -68,7 +68,7 @@ def mem_estimate_coclustering_numpy(n_rows,
     logger.info('Estimated memory usage: {:.2f}{}, peak number: {}'.format(
         mem_usage, unit, peak))
 
-    return (mem_usage, unit, peak)
+    return mem_usage, unit, peak
 
 
 def _est_arr_size(shape, nbytes=8):
@@ -184,7 +184,7 @@ def calculate_cluster_feature(Z, function, clusters, nclusters=None, **kwargs):
     :param Z: Data array (N dimensions).
     :type Z: numpy.ndarray or dask.array.Array
     :param function: Function to run over the cluster elements to calculate the
-        desidered feature. Should take as an input a N-dimensional array and
+        desired feature. Should take as an input a N-dimensional array and
         return a scalar.
     :type function: Callable
     :param clusters: Iterable with length N. It should contain the cluster

--- a/docs/kmeans.rst
+++ b/docs/kmeans.rst
@@ -4,7 +4,7 @@ K-means refinement
 Introduction
 ------------
 
-The `Kmeans` module is an implementation of the `k-means clustering`_ to refine the results of a co-clustering or
+The `kmeans` module is an implementation of the `k-means clustering`_ to refine the results of a co-clustering or
 tri-clustering calculation. This k-mean refinement allows identifying similarity patterns between co- or tri-clusters.
 The following pre-defined features, computed over all elements belonging to the same co- or tri-cluster, are employed
 for the k-means clustering:
@@ -37,24 +37,24 @@ The k-means refinement should be based on existing co- or tri-clustering results
     row_clusters = np.array([0, 0, 1, 2])  # 3 clusters
     col_cluster = np.array([0, 0, 1])  # 2 clusters
 
-One can then setup ``Kmeans`` in the following way:
+One can then setup ``KMeans`` in the following way:
 
 .. code-block:: python
 
-    from cgc.kmeans import Kmeans
+    from cgc.kmeans import KMeans
 
-    km = Kmeans(
+    km = KMeans(
         Z,
         clusters=(row_clusters, col_cluster),
         nclusters=(3, 2)
         k_range=range(2, 5),
-        kmean_max_iter=100,
+        kmeans_max_iter=100,
         output_filename='results.json' # JSON file where to write output
     )
 
 Here ``k_range`` is the range of ``k`` values to investigate. If not provided, a sensible range will be setup (from 2 to
 a fraction of the number of co- or tri-clusters - the optional `max_k_ratio` argument allows for additional control, see
-:ref:`API<API>`). ``kmean_max_iter`` is the maximum number of iterations employed for the k-means clustering.
+:ref:`API<API>`). ``kmeans_max_iter`` is the maximum number of iterations employed for the k-means clustering.
 
 The ``compute`` function is then called to run the k-means refinement:
 
@@ -66,7 +66,7 @@ Results
 -------
 
 The optimal ``k`` value and the refined cluster averages computed over all elements assigned to the co- and tri-clusters
-are stored in the ``KmeansResults`` object:
+are stored in the ``KMeansResults`` object:
 
 .. code-block:: python
 
@@ -83,8 +83,8 @@ API
 
 .. currentmodule:: cgc.kmeans
 
-.. autoclass:: Kmeans
+.. autoclass:: KMeans
     :members:
     :undoc-members:
 
-.. autoclass:: KmeansResults
+.. autoclass:: KMeansResults

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from cgc.kmeans import Kmeans
+from cgc.kmeans import KMeans
 
 
 def init_cocluster_km():
@@ -28,12 +28,12 @@ def init_cocluster_km():
     clusters = [row_clusters, col_clusters]
     nclusters = [nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmean_max_iter = 2
-    km = Kmeans(Z=Z,
+    kmeans_max_iter = 2
+    km = KMeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
                 k_range=k_range,
-                kmean_max_iter=kmean_max_iter)
+                kmeans_max_iter=kmeans_max_iter)
     return km
 
 
@@ -51,12 +51,12 @@ def init_cocluster_km_with_noise():
     clusters = [row_clusters, col_clusters]
     nclusters = [nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmean_max_iter = 2
-    km = Kmeans(Z=Z,
+    kmeans_max_iter = 2
+    km = KMeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
                 k_range=k_range,
-                kmean_max_iter=kmean_max_iter)
+                kmeans_max_iter=kmeans_max_iter)
     return km
 
 
@@ -72,43 +72,43 @@ def init_tricluster_km():
     clusters = [band_clusters, row_clusters, col_clusters]
     nclusters = [nband_clusters, nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmean_max_iter = 2
-    km = Kmeans(Z=Z,
+    kmeans_max_iter = 2
+    km = KMeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
                 k_range=k_range,
-                kmean_max_iter=kmean_max_iter)
+                kmeans_max_iter=kmeans_max_iter)
     return km
 
 
-class TestKmeans(unittest.TestCase):
+class TestKMeans(unittest.TestCase):
     def test_Z_and_cluster_shape_not_match(self):
         with self.assertRaises(ValueError):
-            Kmeans(Z=np.random.random((5, 5)),
+            KMeans(Z=np.random.random((5, 5)),
                    clusters=[[0, 0, 1, 1, 2], [0, 0, 1, 1]],
                    nclusters=[3, 2])
 
     def test_Z_and_cluster_dimension_not_match(self):
         with self.assertRaises(ValueError):
-            Kmeans(Z=np.random.random((5, 4)),
+            KMeans(Z=np.random.random((5, 4)),
                    clusters=[[0, 0, 1, 1, 2], [0, 0, 1, 1], [0, 0, 1, 1]],
                    nclusters=[3, 2, 2])
 
     def test_max_label_equal_ncluster(self):
         with self.assertRaises(ValueError):
-            Kmeans(Z=np.random.random((5, 4, 4)),
+            KMeans(Z=np.random.random((5, 4, 4)),
                    clusters=[[0, 0, 1, 1, 2], [0, 0, 1, 1], [0, 0, 1, 1]],
                    nclusters=[3, 2, 1])
 
     def test_max_label_exceeds_ncluster(self):
         with self.assertRaises(ValueError):
-            Kmeans(Z=np.random.random((5, 4, 4)),
+            KMeans(Z=np.random.random((5, 4, 4)),
                    clusters=[[0, 0, 1, 1, 2], [0, 0, 1, 1], [0, 0, 1, 1]],
                    nclusters=[2, 2, 2])
 
     def test_kvalues_exceed_number_of_coclusters(self):
         with self.assertRaises(ValueError):
-            Kmeans(
+            KMeans(
                 Z=np.random.random((6, 4)),
                 clusters=[[0, 0, 1, 1, 2, 2], [0, 0, 1, 1]],
                 nclusters=[3, 2],
@@ -117,7 +117,7 @@ class TestKmeans(unittest.TestCase):
 
     def test_kvalues_exceed_number_of_coclusters_populated(self):
         with self.assertRaises(ValueError):
-            Kmeans(
+            KMeans(
                 Z=np.random.random((6, 4)),
                 clusters=[[0, 0, 1, 1, 2, 2], [0, 0, 1, 1]],
                 nclusters=[4, 2],
@@ -132,7 +132,7 @@ class TestKmeans(unittest.TestCase):
                                                        0.]])
         self.assertTrue(np.all(results == km.stat_measures_norm))
 
-    def test_kmean_labels_coclustering(self):
+    def test_kmeans_labels_coclustering(self):
         km = init_cocluster_km()
         km.compute()
 
@@ -166,7 +166,7 @@ class TestKmeans(unittest.TestCase):
         km.compute()
         self.assertEqual(km.results.k_value, 3)
 
-    def test_kmean_labels_triclustering(self):
+    def test_kmeans_labels_triclustering(self):
         km = init_tricluster_km()
         km.compute()
 
@@ -229,13 +229,13 @@ class TestKmeans(unittest.TestCase):
         Z = Z + np.random.rand(*Z.shape) * 0.1
         row_cluseters = np.array([0, 0, 1, 1])
         col_clusters = np.array([0, 0, 0, 1, 1])
-        km = Kmeans(Z=Z,
+        km = KMeans(Z=Z,
                     clusters=[row_cluseters, col_clusters],
                     nclusters=[2, 2],
                     k_range=range(2, 4))
         res1 = km.compute()
         self.assertEqual(res1.k_value, 2)
-        km = Kmeans(Z=Z,
+        km = KMeans(Z=Z,
                     clusters=[row_cluseters, col_clusters],
                     nclusters=[2, 2],
                     k_range=range(3, 1, -1))

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -264,12 +264,12 @@ class TestKMeans(unittest.TestCase):
         clusters = [row_clusters, col_clusters]
         nclusters = [nrow_clusters, ncol_clusters]
         k_range = [2, 3]
-        kmean_max_iter = 100
-        km = Kmeans(Z=Z,
+        kmeans_max_iter = 100
+        km = KMeans(Z=Z,
                     clusters=clusters,
                     nclusters=nclusters,
                     k_range=k_range,
-                    kmean_max_iter=kmean_max_iter,
+                    kmeans_max_iter=kmeans_max_iter,
                     statistics=(np.mean, (np.std, {'axis': None})))
         res = km.compute()
         assert res.input_parameters["statistics"][0][0] == "mean"
@@ -291,14 +291,14 @@ class TestKMeans(unittest.TestCase):
         clusters = [row_clusters, col_clusters]
         nclusters = [nrow_clusters, ncol_clusters]
         k_range = [2, 3]
-        kmean_max_iter = 100
+        kmeans_max_iter = 100
 
         def run_kmeans(statistics=None):
-            km = Kmeans(Z=Z,
+            km = KMeans(Z=Z,
                         clusters=clusters,
                         nclusters=nclusters,
                         k_range=k_range,
-                        kmean_max_iter=kmean_max_iter,
+                        kmeans_max_iter=kmeans_max_iter,
                         statistics=statistics)
             res = km.compute()
             return res.k_value


### PR DESCRIPTION
Mostly, copy returned results objects (additional calculations do not affect returned results). Some typo fixes here and there (mostly, use `kmeans` consistently, also keeping the same capitalisation as sklearn).
