### PR TITLE
Easier configuration of k-means

### DIFF
--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -24,7 +24,7 @@ class KMeansResults(Results):
     """
     Contains results and metadata of a k-means refinement calculation.
 
-    :var k_value: Optimal K value (value with maximum Silhouette score).
+    :var k_value: Optimal K value (value with maximum silhouette score).
     :type k_value: int
     :var labels: Refined clusters labels. It is a 2D- (for coclustering)
                  or 3D- (for triclustering) array, with the shape of
@@ -32,7 +32,7 @@ class KMeansResults(Results):
                  represents the refined cluster label of the corresponding
                  band/row/column cluster combination.
     :type labels: np.ndarray
-    :var measure_list: List of Silhouette coefficients for all tested k values.
+    :var measure_list: List of silhouette coefficients for all tested k values.
     :type measure_list: np.ndarray
     :var cluster_averages: Refined cluster averages. They are computed as means
         over all elements of the co-/tri-clusters assigned to the refined
@@ -52,7 +52,7 @@ class KMeans(object):
     A set of statistics is computed for all co- or tri-clusters, then these
     clusters are in turned grouped using k-means. K-means clustering is
     performed for multiple k values, then the optimal value is selected on the
-    basis of the Silhouette coefficient.
+    basis of the silhouette coefficient.
 
     :param Z: Data array (N dimensions).
     :type Z: numpy.ndarray or dask.array.Array
@@ -176,8 +176,8 @@ class KMeans(object):
     def compute(self, recalc_statistics=False):
         """
         Compute statistics for each clustering group. Then loop through the
-        range of k values, and compute the averaged Silhouette measure of each
-        k value. Finally select the k with the maximum Silhouette measure.
+        range of k values, and compute the averaged silhouette measure of each
+        k value. Finally select the k with the maximum silhouette measure.
 
         :param recalc_statistics: If True, always recompute statistics.
         :type recalc_statistics: bool, optional

--- a/cgc/kmeans.py
+++ b/cgc/kmeans.py
@@ -204,14 +204,16 @@ class KMeans(object):
             kmeans_label_list.append(kmeans_cluster.labels_)
         idx_k = np.argmax(silhouette_avg_list)
         if np.sum(silhouette_avg_list == silhouette_avg_list[idx_k]) > 1:
-            idx_k_list = np.argwhere(
-                silhouette_avg_list == silhouette_avg_list[idx_k]).reshape(
-                    -1).tolist()
+            idx_ks = np.argwhere(
+                silhouette_avg_list == silhouette_avg_list[idx_k]
+            )
             logger.warning(
                 "Multiple k values with the same silhouette score: {},"
                 "picking the smallest one: {}".format(
-                    [self.k_range[i] for i in idx_k_list],
-                    self.k_range[idx_k]))
+                    [self.k_range[i] for i in idx_ks.flatten()],
+                    self.k_range[idx_k]
+                )
+            )
         self.results.measure_list = silhouette_avg_list
         self.results.k_value = self.k_range[idx_k]
         labels = kmeans_label_list[idx_k]

--- a/docs/kmeans.rst
+++ b/docs/kmeans.rst
@@ -18,10 +18,10 @@ for the k-means clustering:
 
 However, the user can customize the set of statistics computed over the clusters.
 The implementation, which is based on the `scikit-learn`_ package, tests a range of k values and select the optimal one
-based on the `Silhouette coefficient`_.
+based on the `silhouette coefficient`_.
 
 .. _scikit-learn: https://scikit-learn.org/stable/index.html
-.. _Silhouette coefficient: https://en.wikipedia.org/wiki/Silhouette_(clustering)
+.. _silhouette coefficient: https://en.wikipedia.org/wiki/Silhouette_(clustering)
 
 Running the refinement
 ----------------------

--- a/docs/kmeans.rst
+++ b/docs/kmeans.rst
@@ -49,15 +49,17 @@ One can then setup ``KMeans`` in the following way:
         clusters=(row_clusters, col_cluster),
         nclusters=(3, 2)
         k_range=range(2, 5),
-        kmeans_max_iter=100,
+        kmeans_kwargs={'init': 'random', 'n_init': 100},
         output_filename='results.json' # JSON file where to write output
     )
 
 Here ``k_range`` is the range of ``k`` values to investigate. If not provided, a sensible range will be setup (from 2 to
 a fraction of the number of co- or tri-clusters - the optional ``max_k_ratio`` argument allows for additional control,
-see :ref:`API<API>`). ``kmeans_max_iter`` is the maximum number of iterations employed for the k-means clustering. By
-using the optional argument ``statistics``, the user can define a custom set of statistics employed for the k-means
-refinement (see the :ref:`API<API>`).
+see :ref:`API<API>`). ``kmeans_kwargs`` contains input arguments passed on to the `scikit-learn KMeans object`_ upon
+initialization (here we define the initialization procedure). By using the optional argument ``statistics``, the user
+can define a custom set of statistics employed for the k-means refinement (see the :ref:`API<API>`).
+
+.. _scikit-learn KMeans object: https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html
 
 The ``compute`` function is then called to run the k-means refinement:
 

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -28,12 +28,12 @@ def init_cocluster_km():
     clusters = [row_clusters, col_clusters]
     nclusters = [nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmeans_max_iter = 100
+    kmeans_kwargs = {"init": "k-means++", "n_init": "auto"}
     km = KMeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
                 k_range=k_range,
-                kmeans_max_iter=kmeans_max_iter)
+                kmeans_kwargs=kmeans_kwargs)
     return km
 
 
@@ -51,12 +51,12 @@ def init_cocluster_km_with_noise():
     clusters = [row_clusters, col_clusters]
     nclusters = [nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmeans_max_iter = 2
+    kmeans_kwargs = {"init": "k-means++", "n_init": "auto"}
     km = KMeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
                 k_range=k_range,
-                kmeans_max_iter=kmeans_max_iter)
+                kmeans_kwargs=kmeans_kwargs)
     return km
 
 
@@ -72,12 +72,12 @@ def init_tricluster_km():
     clusters = [band_clusters, row_clusters, col_clusters]
     nclusters = [nband_clusters, nrow_clusters, ncol_clusters]
     k_range = range(2, 4)
-    kmeans_max_iter = 2
+    kmeans_kwargs = {"init": "k-means++", "n_init": "auto"}
     km = KMeans(Z=Z,
                 clusters=clusters,
                 nclusters=nclusters,
                 k_range=k_range,
-                kmeans_max_iter=kmeans_max_iter)
+                kmeans_kwargs=kmeans_kwargs)
     return km
 
 
@@ -264,12 +264,10 @@ class TestKMeans(unittest.TestCase):
         clusters = [row_clusters, col_clusters]
         nclusters = [nrow_clusters, ncol_clusters]
         k_range = [2, 3]
-        kmeans_max_iter = 100
         km = KMeans(Z=Z,
                     clusters=clusters,
                     nclusters=nclusters,
                     k_range=k_range,
-                    kmeans_max_iter=kmeans_max_iter,
                     statistics=(np.mean, (np.std, {'axis': None})))
         res = km.compute()
         assert res.input_parameters["statistics"][0][0] == "mean"
@@ -291,14 +289,14 @@ class TestKMeans(unittest.TestCase):
         clusters = [row_clusters, col_clusters]
         nclusters = [nrow_clusters, ncol_clusters]
         k_range = [2, 3]
-        kmeans_max_iter = 100
+        kmeans_kwargs = {"init": "k-means++", "n_init": "auto"}
 
         def run_kmeans(statistics=None):
             km = KMeans(Z=Z,
                         clusters=clusters,
                         nclusters=nclusters,
                         k_range=k_range,
-                        kmeans_max_iter=kmeans_max_iter,
+                        kmeans_kwargs=kmeans_kwargs,
                         statistics=statistics)
             res = km.compute()
             return res.k_value


### PR DESCRIPTION
Until now, one could only configure the max number of iterations performed within the k-means refinement. This PR makes it possible to better configure the scikit-learn k-means runs with arbitrary kwargs.

We also add the inertia inertia computed vs k values to the output (e.g. useful to make elbow plots).